### PR TITLE
fix: 카카오 로그아웃 후 재 로그인 수정

### DIFF
--- a/peloton-frontend/component/login/KakaoLoginWebView.js
+++ b/peloton-frontend/component/login/KakaoLoginWebView.js
@@ -42,7 +42,7 @@ const KakaoLoginWebView = ({ toggleModal }) => {
     if (accessToken) {
       toggleModal();
       setToken(accessToken);
-      if (isCreated) {
+      if (isCreated === "true") {
         navigation.navigate("ChangeNickname");
       } else {
         navigateWithoutHistory(navigation, "ApplicationNavigationRoot");


### PR DESCRIPTION
재 로그인 시 닉네임 변경화면으로 이동하는 버그 수정