### PR TITLE
refactor: member id, certification id 쌍이 이미 존재할 때, 예외처리 구현

### DIFF
--- a/src/main/java/com/woowacourse/pelotonbackend/report/domain/ReportRepositoryCustomImpl.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/report/domain/ReportRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.woowacourse.pelotonbackend.report.domain;
 
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -23,8 +24,11 @@ public class ReportRepositoryCustomImpl implements ReportRepositoryCustom {
             return jdbcOperations.queryForObject(existsReportByMemberIdAndCertificationId(), parameterSource,
                 Boolean.class);
         } catch (EmptyResultDataAccessException e) {
-            // todo : 데이터가 2개 이상일 경우에도 예외 처리
             return false;
+        } catch (IncorrectResultSizeDataAccessException e) {
+            throw new AssertionError(
+                String.format("There should not be duplicated (member_id, certification_id), but (%d, %d)",
+                    memberId, certificationId));
         }
     }
 

--- a/src/test/java/com/woowacourse/pelotonbackend/report/domain/ReportRepositoryTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/report/domain/ReportRepositoryTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 @SpringBootTest
 class ReportRepositoryTest {
@@ -58,9 +57,8 @@ class ReportRepositoryTest {
         reportRepository.save(report);
         reportRepository.save(anotherReport);
 
-        assertThatThrownBy(() -> {
-            reportRepository.existsByMemberIdAndCertificationId(MEMBER_ID, CERTIFICATION_ID);
-        })
-        .isInstanceOf(AssertionError.class);
+        assertThatThrownBy(() -> reportRepository.existsByMemberIdAndCertificationId(MEMBER_ID, CERTIFICATION_ID))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("There should not be duplicated (member_id, certification_id)");
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/report/domain/ReportRepositoryTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/report/domain/ReportRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 @SpringBootTest
 class ReportRepositoryTest {
@@ -46,5 +47,20 @@ class ReportRepositoryTest {
         final boolean notExistReport = reportRepository.existsByMemberIdAndCertificationId(10L, 10L);
 
         assertThat(notExistReport).isFalse();
+    }
+
+    @DisplayName("MemberId와 CertificationId가 중복되는 데이터가 있다면 AssertionError")
+    @Test
+    void throwErrorIfMemberIdAndCertificationIdDuplicate() {
+        final Report report = ReportFixture.createWithoutId();
+        final Report anotherReport = ReportFixture.createWithoutId();
+
+        reportRepository.save(report);
+        reportRepository.save(anotherReport);
+
+        assertThatThrownBy(() -> {
+            reportRepository.existsByMemberIdAndCertificationId(MEMBER_ID, CERTIFICATION_ID);
+        })
+        .isInstanceOf(AssertionError.class);
     }
 }


### PR DESCRIPTION
close #161 