### PR TITLE
인덱스 페이지 구현

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Peloton API</title>
+</head>
+<body>
+<h1>This is Peloton API Server!</h1>
+</body>
+</html>


### PR DESCRIPTION
SSL 인증서를 발급하려면 인덱스 페이지에서 404 오류가 나면 안됩니다.