### PR TITLE
feat: 중복된 엔티티 생성요청에 대한 방어로직 구현

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -204,6 +204,10 @@ operation::certification/create-success[snippets='http-request,http-response,req
 ==== Failure
 operation::certification/create-fail[snippets='http-request,http-response,request-parameters,request-parts,response-headers,response-fields']
 
+[[resources-certification-create-duplicated]]
+==== Duplicated
+operation::certification/create-duplicated[snippets='http-request,http-response,request-parameters,request-parts,response-fields']
+
 [[resources-certification-get-certification]]
 ==== Success
 operation::certification/get-certification[snippets='http-request,http-response,path-parameters,request-headers,response-headers,response-fields']
@@ -447,6 +451,10 @@ operation::mission/delete-success[snippets='http-request,http-response,path-para
 ==== Success
 operation::report/create-success[snippets='http-request,http-response,request-headers,request-fields,response-headers']
 
+[[resources-report-create-duplicated]]
+==== Duplicated
+operation::report/create-duplicated[snippets='http-request,http-response,request-headers,request-fields,response-fields']
+
 [[resources-rider]]
 == Rider
 
@@ -454,10 +462,14 @@ operation::report/create-success[snippets='http-request,http-response,request-he
 [[resources-rider-create]]
 === Create Rider
 
-
 [[resources-rider-create-success]]
 ==== Success
 operation::rider/create-success[snippets='http-request,http-response,request-headers,request-fields,response-headers']
+
+
+[[resources-rider-create-duplicated]]
+==== Duplicated
+operation::rider/create-duplicated[snippets='http-request,http-response,request-headers,request-fields,response-fields']
 
 [[resources-rider-get]]
 === Get Rider

--- a/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryCustom.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface CertificationRepositoryCustom {
     Page<Certification> findByRiderId(Long id, Pageable pageable);
 
     Page<Certification> findByMissionIds(List<Long> missionIds, Pageable pageable);
+
+    boolean existsByRiderIdAndMissionId(Long riderId, Long missionId);
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryCustomImpl.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryCustomImpl.java
@@ -74,7 +74,7 @@ public class CertificationRepositoryCustomImpl implements CertificationRepositor
             return false;
         } catch (IncorrectResultSizeDataAccessException e) {
             throw new AssertionError(
-                String.format("There should not be duplicated (member_id, race_id), but (%d, %d)",
+                String.format("There should not be duplicated (rider_id, mission_id), but (%d, %d)",
                     riderId, missionId));
         }
     }

--- a/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryCustomImpl.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryCustomImpl.java
@@ -69,7 +69,7 @@ public class CertificationRepositoryCustomImpl implements CertificationRepositor
             .addValue("missionId", missionId);
 
         try {
-            return jdbcOperations.queryForObject(existsCertificationByRiderIdAndMissionId(), parameterSource, Boolean.class);
+            return jdbcOperations.queryForObject(existsCertificationByRiderIdAndMissionIdSql(), parameterSource, Boolean.class);
         } catch (EmptyResultDataAccessException e) {
             return false;
         } catch (IncorrectResultSizeDataAccessException e) {

--- a/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryCustomImpl.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryCustomImpl.java
@@ -1,7 +1,11 @@
 package com.woowacourse.pelotonbackend.certification.domain;
 
+import static com.woowacourse.pelotonbackend.certification.domain.CertificationSql.*;
+
 import java.util.List;
 
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jdbc.core.convert.EntityRowMapper;
@@ -56,5 +60,22 @@ public class CertificationRepositoryCustomImpl implements CertificationRepositor
 
         return PageableExecutionUtils.getPage(certifications, pageable, () ->
             this.jdbcOperations.queryForObject(CertificationSql.countByMissionIds(), parameterSource, Long.class));
+    }
+
+    @Override
+    public boolean existsByRiderIdAndMissionId(final Long riderId, final Long missionId) {
+        final SqlParameterSource parameterSource = new MapSqlParameterSource()
+            .addValue("riderId", riderId)
+            .addValue("missionId", missionId);
+
+        try {
+            return jdbcOperations.queryForObject(existsCertificationByRiderIdAndMissionId(), parameterSource, Boolean.class);
+        } catch (EmptyResultDataAccessException e) {
+            return false;
+        } catch (IncorrectResultSizeDataAccessException e) {
+            throw new AssertionError(
+                String.format("There should not be duplicated (member_id, race_id), but (%d, %d)",
+                    riderId, missionId));
+        }
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationSql.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationSql.java
@@ -40,4 +40,12 @@ public class CertificationSql {
             .append(" WHERE MISSION_ID IN (:missionIds)")
             .toString();
     }
+
+    static String existsCertificationByRiderIdAndMissionId() {
+        return new StringBuilder()
+            .append("SELECT CERTIFICATION.ID AS ID")
+            .append(" FROM CERTIFICATION")
+            .append(" WHERE CERTIFICATION.RIDER_ID = :riderId AND CERTIFICATION.MISSION_ID = :missionId")
+            .toString();
+    }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationSql.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/certification/domain/CertificationSql.java
@@ -41,7 +41,7 @@ public class CertificationSql {
             .toString();
     }
 
-    static String existsCertificationByRiderIdAndMissionId() {
+    static String existsCertificationByRiderIdAndMissionIdSql() {
         return new StringBuilder()
             .append("SELECT CERTIFICATION.ID AS ID")
             .append(" FROM CERTIFICATION")

--- a/src/main/java/com/woowacourse/pelotonbackend/common/ErrorCode.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/common/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode {
 
     FILE_UPLOAD(400, "File-004"),
 
-    CERTIFICATION_NOT_FOUND(404, "Certification-001");
+    CERTIFICATION_NOT_FOUND(404, "Certification-001"),
+    CERTIFICATION_DUPLICATE(400, "Certification-002");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/woowacourse/pelotonbackend/common/ErrorCode.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/common/ErrorCode.java
@@ -27,15 +27,16 @@ public enum ErrorCode {
     MISSION_DUPLICATE(400, "Mission-002"),
     MISSION_ID_INVALID(400, "Mission-003"),
 
-    RIDER_NOT_FOUND(404,"RIDER-001"),
+    RIDER_NOT_FOUND(404,"Rider-001"),
+    RIDER_DUPLICATE(400, "Rider-002"),
 
     UN_AUTHORIZED(401, "Auth-001"),
     TOKEN_EXPIRED(401, "Auth-002"),
     INVALID_TOKEN(401, "Auth-003"),
 
-    FILE_UPLOAD(400, "FILE-004"),
+    FILE_UPLOAD(400, "File-004"),
 
-    CERTIFICATION_NOT_FOUND(404, "CERTIFICATION-001");
+    CERTIFICATION_NOT_FOUND(404, "Certification-001");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/woowacourse/pelotonbackend/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/common/GlobalExceptionHandler.java
@@ -17,9 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
-
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ErrorResponse> validException(final MethodArgumentNotValidException exception) {
+    public ResponseEntity<ErrorResponse> validException(final MethodArgumentNotValidException exception) {
         log.info("Validate Exception ! : {} ", exception.toString(), exception);
 
         final ErrorCode errorCode = ErrorCode.INVALID_VALIDATE;
@@ -30,7 +29,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(BindException.class)
-    protected ResponseEntity<ErrorResponse> bindException(final BindException exception) {
+    public ResponseEntity<ErrorResponse> bindException(final BindException exception) {
         log.info("HandleBind Exception ! : {} ", exception.toString(), exception);
 
         final ErrorCode errorCode = ErrorCode.INVALID_VALIDATE;
@@ -45,7 +44,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({ConstraintViolationException.class, HttpMessageNotReadableException.class,
         MethodArgumentTypeMismatchException.class})
-    protected ResponseEntity<ErrorResponse> invalidInputException(final RuntimeException exception) {
+    public ResponseEntity<ErrorResponse> invalidInputException(final RuntimeException exception) {
         log.info(exception.getClass().getSimpleName() + " Exception !", exception);
 
         final ErrorCode errorCode = ErrorCode.INVALID_VALIDATE;
@@ -56,7 +55,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(BusinessException.class)
-    protected ResponseEntity<ErrorResponse> businessException(final BusinessException exception) {
+    public ResponseEntity<ErrorResponse> businessException(final BusinessException exception) {
         log.info("Business Exception ! : {}", exception.toString(), exception);
 
         final ErrorCode errorCode = exception.getErrorCode();
@@ -69,7 +68,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> UnexpectedException(final Exception exception) {
+    public ResponseEntity<ErrorResponse> UnexpectedException(final Exception exception) {
         log.error("Unexpected Exception ! {} ", exception.toString(), exception);
 
         final ErrorResponse errorResponse = ErrorResponse.of(

--- a/src/main/java/com/woowacourse/pelotonbackend/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/common/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> validException(final MethodArgumentNotValidException exception) {
+    protected ResponseEntity<ErrorResponse> validException(final MethodArgumentNotValidException exception) {
         log.info("Validate Exception ! : {} ", exception.toString(), exception);
 
         final ErrorCode errorCode = ErrorCode.INVALID_VALIDATE;
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(BindException.class)
-    public ResponseEntity<ErrorResponse> bindException(final BindException exception) {
+    protected ResponseEntity<ErrorResponse> bindException(final BindException exception) {
         log.info("HandleBind Exception ! : {} ", exception.toString(), exception);
 
         final ErrorCode errorCode = ErrorCode.INVALID_VALIDATE;
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({ConstraintViolationException.class, HttpMessageNotReadableException.class,
         MethodArgumentTypeMismatchException.class})
-    public ResponseEntity<ErrorResponse> invalidInputException(final RuntimeException exception) {
+    protected ResponseEntity<ErrorResponse> invalidInputException(final RuntimeException exception) {
         log.info(exception.getClass().getSimpleName() + " Exception !", exception);
 
         final ErrorCode errorCode = ErrorCode.INVALID_VALIDATE;
@@ -55,7 +55,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ErrorResponse> businessException(final BusinessException exception) {
+    protected ResponseEntity<ErrorResponse> businessException(final BusinessException exception) {
         log.info("Business Exception ! : {}", exception.toString(), exception);
 
         final ErrorCode errorCode = exception.getErrorCode();
@@ -68,7 +68,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> UnexpectedException(final Exception exception) {
+    protected ResponseEntity<ErrorResponse> UnexpectedException(final Exception exception) {
         log.error("Unexpected Exception ! {} ", exception.toString(), exception);
 
         final ErrorResponse errorResponse = ErrorResponse.of(

--- a/src/main/java/com/woowacourse/pelotonbackend/common/exception/CertificationDuplicatedException.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/common/exception/CertificationDuplicatedException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.pelotonbackend.common.exception;
+
+import com.woowacourse.pelotonbackend.common.ErrorCode;
+
+public class CertificationDuplicatedException extends DuplicateException {
+    public CertificationDuplicatedException(final Long riderId, final Long missionId) {
+        super(ErrorCode.CERTIFICATION_DUPLICATE,
+            String.format("Certification(rider id: %d, mission id: %d) already exists!", riderId, missionId));
+    }
+}

--- a/src/main/java/com/woowacourse/pelotonbackend/common/exception/RiderDuplicatedException.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/common/exception/RiderDuplicatedException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.pelotonbackend.common.exception;
+
+import com.woowacourse.pelotonbackend.common.ErrorCode;
+
+public class RiderDuplicatedException extends DuplicateException {
+    public RiderDuplicatedException(final Long memberId, final Long raceId) {
+        super(ErrorCode.RIDER_DUPLICATE,
+            String.format("Rider(member id: %d, certification id: %d) already exists!", memberId, raceId));
+    }
+}

--- a/src/main/java/com/woowacourse/pelotonbackend/rider/application/RiderService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/rider/application/RiderService.java
@@ -2,9 +2,12 @@ package com.woowacourse.pelotonbackend.rider.application;
 
 import java.util.List;
 
+import javax.validation.constraints.NotNull;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.woowacourse.pelotonbackend.common.exception.RiderDuplicatedException;
 import com.woowacourse.pelotonbackend.common.exception.RiderNotFoundException;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.rider.domain.Rider;
@@ -22,6 +25,13 @@ public class RiderService {
     private final RiderRepository riderRepository;
 
     public Long create(final MemberResponse member, final RiderCreateRequest riderCreateRequest) {
+        final Long memberId = member.getId();
+        final Long raceId = riderCreateRequest.getRaceId();
+
+        final boolean isRiderAlreadyExists = riderRepository.existsByMemberIdAndRaceID(memberId, raceId);
+        if (isRiderAlreadyExists) {
+            throw new RiderDuplicatedException(memberId, raceId);
+        }
         final Rider riderWithoutId = riderCreateRequest.toRider(member);
 
         return riderRepository.save(riderWithoutId).getId();

--- a/src/main/java/com/woowacourse/pelotonbackend/rider/domain/RiderCustomRepository.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/rider/domain/RiderCustomRepository.java
@@ -6,4 +6,6 @@ public interface RiderCustomRepository {
     List<Rider> findRidersByRaceId(Long raceId);
 
     List<Rider> findRidersByMemberId(Long memberId);
+
+    boolean existsByMemberIdAndRaceID(Long memberId, Long raceId);
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/rider/domain/RiderRepositoryImpl.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/rider/domain/RiderRepositoryImpl.java
@@ -84,7 +84,7 @@ public class RiderRepositoryImpl implements RiderCustomRepository {
         return new StringBuilder()
             .append("SELECT RIDER.ID AS ID")
             .append(" FROM RIDER")
-            .append(" WHERE MEMBER_ID = :memberId AND RACE_ID = :raceId")
+            .append(" WHERE RIDER.MEMBER_ID = :memberId AND RIDER.RACE_ID = :raceId")
             .toString();
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/rider/domain/RiderRepositoryImpl.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/rider/domain/RiderRepositoryImpl.java
@@ -2,12 +2,15 @@ package com.woowacourse.pelotonbackend.rider.domain;
 
 import java.util.List;
 
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.data.jdbc.core.convert.EntityRowMapper;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 public class RiderRepositoryImpl implements RiderCustomRepository {
     private final NamedParameterJdbcOperations operations;
@@ -40,6 +43,23 @@ public class RiderRepositoryImpl implements RiderCustomRepository {
         return operations.query(findByMemberId(), parameterSource, this.rowMapper);
     }
 
+    @Override
+    public boolean existsByMemberIdAndRaceID(final Long memberId, final Long raceId) {
+        final SqlParameterSource parameterSource = new MapSqlParameterSource()
+            .addValue("memberId", memberId)
+            .addValue("raceId", raceId);
+
+        try {
+            return operations.queryForObject(existsRiderByMemberIdAndRaceId(), parameterSource, Boolean.class);
+        } catch (EmptyResultDataAccessException e) {
+            return false;
+        } catch (IncorrectResultSizeDataAccessException e) {
+            throw new AssertionError(
+                String.format("There should not be duplicated (member_id, race_id), but (%d, %d)",
+                    memberId, raceId));
+        }
+    }
+
     private static String findByRiderId() {
         return new StringBuilder()
             .append("SELECT RIDER.ID AS ID")
@@ -57,6 +77,14 @@ public class RiderRepositoryImpl implements RiderCustomRepository {
             .append(", RIDER.CREATED_AT AS CREATED_AT, RIDER.UPDATED_AT AS UPDATED_AT")
             .append(" FROM RIDER")
             .append(" WHERE MEMBER_ID = :memberId")
+            .toString();
+    }
+
+    private static String existsRiderByMemberIdAndRaceId() {
+        return new StringBuilder()
+            .append("SELECT RIDER.ID AS ID")
+            .append(" FROM RIDER")
+            .append(" WHERE MEMBER_ID = :memberId AND RACE_ID = :raceId")
             .toString();
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryTest.java
@@ -85,4 +85,14 @@ class CertificationRepositoryTest {
             () -> assertThat(certifications.getContent().get(0).getId()).isEqualTo(1L)
         );
     }
+
+    @Test
+    void existsByRiderIdAndMissionId() {
+        final Certification certification = createCertificationWithoutId();
+        certificationRepository.save(certification);
+        certificationRepository.save(certification);
+
+        assertThatThrownBy(() -> certificationRepository.existsByRiderIdAndMissionId(certification.getRiderId().getId(),
+            certification.getMissionId().getId())).isInstanceOf(AssertionError.class);
+    }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/certification/domain/CertificationRepositoryTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 
+import javax.validation.constraints.NotNull;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,13 +88,37 @@ class CertificationRepositoryTest {
         );
     }
 
+    @DisplayName("라이더 id와 미션 id로 Rider가 존재하는 지 확인한다.")
     @Test
     void existsByRiderIdAndMissionId() {
         final Certification certification = createCertificationWithoutId();
         certificationRepository.save(certification);
+
+        assertThat(certificationRepository.existsByRiderIdAndMissionId(certification.getRiderId().getId(),
+            certification.getMissionId().getId())).isTrue();
+    }
+
+    @DisplayName("라이더 id와 미션 id로 존재하지 않는 Rider가 존재하지 않는 지 확인한다.")
+    @Test
+    void notExistsByRiderIdAndMissionId() {
+        final Certification certification = createCertificationWithoutId();
+
+        assertThat(certificationRepository.existsByRiderIdAndMissionId(certification.getRiderId().getId(),
+            certification.getMissionId().getId())).isFalse();
+    }
+
+    @DisplayName("라이더 id와 미션 id로 중복된 라이더를 조회 시 예외를 반환한다.")
+    @Test
+    void existsDuplicateByRiderIdAndMissionId() {
+        final Certification certification = createCertificationWithoutId();
+        final Long riderId = certification.getRiderId().getId();
+        final Long missionId = certification.getMissionId().getId();
+        certificationRepository.save(certification);
         certificationRepository.save(certification);
 
-        assertThatThrownBy(() -> certificationRepository.existsByRiderIdAndMissionId(certification.getRiderId().getId(),
-            certification.getMissionId().getId())).isInstanceOf(AssertionError.class);
+        assertThatThrownBy(() -> certificationRepository.existsByRiderIdAndMissionId(riderId, missionId))
+            .isInstanceOf(AssertionError.class)
+            .hasMessage(String.format("There should not be duplicated (rider_id, mission_id), but (%d, %d)", riderId,
+                missionId));
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/CertificationControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/CertificationControllerTest.java
@@ -137,26 +137,12 @@ class CertificationControllerTest {
     @Test
     void createDuplicatedRequest() throws Exception {
         given(certificationService.create(any(MultipartFile.class), any(CertificationCreateRequest.class)))
-            .willReturn(TEST_CERTIFICATION_ID)
             .willThrow(new CertificationDuplicatedException(TEST_RIDER_ID, TEST_MISSION_ID));
         given(authInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class),
             any(HandlerMethod.class))).willReturn(true);
         given(argumentResolver.supportsParameter(any())).willCallRealMethod();
         given(argumentResolver.resolveArgument(any(MethodParameter.class), any(ModelAndViewContainer.class),
             any(NativeWebRequest.class), any(WebDataBinderFactory.class))).willReturn(MemberFixture.memberResponse());
-
-        mockMvc.perform(
-            multipart("/api/certifications", TEST_RIDER_ID, TEST_MISSION_ID)
-                .file(createMockCertificationMultipartFile())
-                .header(HttpHeaders.AUTHORIZATION, LoginFixture.getTokenHeader())
-                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                .param("status", TEST_CERTIFICATION_STATUS.name())
-                .param("description", TEST_CERTIFICATION_DESCRIPTION)
-                .param("riderId", TEST_RIDER_ID.toString())
-                .param("missionId", TEST_MISSION_ID.toString()))
-            .andExpect(status().isCreated())
-            .andExpect(
-                header().stringValues("location", String.format("/api/certifications/%d", TEST_CERTIFICATION_ID)));
 
         mockMvc.perform(
             multipart("/api/certifications", TEST_RIDER_ID, TEST_MISSION_ID)

--- a/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/CertificationControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/CertificationControllerTest.java
@@ -168,7 +168,8 @@ class CertificationControllerTest {
                 .param("description", TEST_CERTIFICATION_DESCRIPTION)
                 .param("riderId", TEST_RIDER_ID.toString())
                 .param("missionId", TEST_MISSION_ID.toString()))
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isBadRequest())
+            .andDo(CertificationDocumentation.createDuplicatedCertification());
     }
 
     @DisplayName("아이디로 인증정보를 조회한다.")

--- a/src/test/java/com/woowacourse/pelotonbackend/docs/CertificationDocumentation.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/docs/CertificationDocumentation.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.*;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.ResultHandler;
 
 public class CertificationDocumentation {
     public static RestDocumentationResultHandler createCertification() {
@@ -177,6 +178,28 @@ public class CertificationDocumentation {
             pathParameters(
                 parameterWithName("id").description("인증 ID")
             )
+        );
+    }
+
+    public static RestDocumentationResultHandler createDuplicatedCertification() {
+        return document("certification/create-duplicated",
+            getDocumentRequest(),
+            getDocumentResponse(),
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION).description("사용자 인증 토큰"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-Type 헤더"),
+                headerWithName(HttpHeaders.ACCEPT).description("Accept 헤더")
+            ),
+            requestParts(
+                partWithName("certification_image").description("인증 사진")
+            ),
+            requestParameters(
+                parameterWithName("status").description("인증 성공 여부"),
+                parameterWithName("description").description("인증 세부내용").optional(),
+                parameterWithName("riderId").description("인증 라이더 ID"),
+                parameterWithName("missionId").description("인증 대상 미션 ID")
+            ),
+            getErrorResponseFields()
         );
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/docs/ReportDocumentation.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/docs/ReportDocumentation.java
@@ -9,6 +9,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 
 import org.apache.http.HttpHeaders;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.ResultHandler;
 
 public class ReportDocumentation {
     public static RestDocumentationResultHandler createReport() {
@@ -27,6 +28,23 @@ public class ReportDocumentation {
             responseHeaders(
                 headerWithName(HttpHeaders.LOCATION).description("Resource의 Location 헤더")
             )
+        );
+    }
+
+    public static RestDocumentationResultHandler createDuplicatedReport() {
+        return document("report/create-duplicated",
+            getDocumentRequest(),
+            getDocumentResponse(),
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION).description("사용자 인증 Access Token 헤더")
+            ),
+            requestFields(
+                fieldWithPath("report_type").type(STRING).attributes(getReportTypeFormat()).description("Report 종류"),
+                fieldWithPath("description").type(STRING).description("Report 상세내용"),
+                fieldWithPath("report_member_id").type(NUMBER).description("신고하는 Member ID"),
+                fieldWithPath("certification_id").type(NUMBER).description("신고하는 Certification ID")
+            ),
+            getErrorResponseFields()
         );
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/docs/RiderDocumentation.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/docs/RiderDocumentation.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 
 import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpHead;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.ResultHandler;
 
@@ -137,9 +138,17 @@ public class RiderDocumentation {
     }
 
     public static RestDocumentationResultHandler createDuplicatedRider() {
-        return document("rider/create-duplicate",
+        return document("rider/create-duplicated",
             getDocumentRequest(),
-            getDocumentResponse()
+            getDocumentResponse(),
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION).description("사용자 인증 Access Token 헤더"),
+                headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-Type 헤더")
+            ),
+            requestFields(
+                fieldWithPath("race_id").type(NUMBER).description("해당 Rider가 참여한 Race ID")
+            ),
+            getErrorResponseFields()
         );
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/docs/RiderDocumentation.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/docs/RiderDocumentation.java
@@ -9,6 +9,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.*;
 
 import org.apache.http.HttpHeaders;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.ResultHandler;
 
 public class RiderDocumentation {
     public static RestDocumentationResultHandler createRider() {
@@ -132,6 +133,13 @@ public class RiderDocumentation {
             requestHeaders(
                 headerWithName(HttpHeaders.AUTHORIZATION).description("사용자 인증 Access Token 헤더")
             )
+        );
+    }
+
+    public static RestDocumentationResultHandler createDuplicatedRider() {
+        return document("rider/create-duplicate",
+            getDocumentRequest(),
+            getDocumentResponse()
         );
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/member/domain/MemberFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/domain/MemberFixture.java
@@ -1,6 +1,7 @@
 package com.woowacourse.pelotonbackend.member.domain;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.assertj.core.util.Lists;
 import org.springframework.mock.web.MockMultipartFile;
@@ -50,6 +51,11 @@ public class MemberFixture {
             .cash(CASH)
             .role(ROLE)
             .build();
+    }
+
+    public static List<MemberCreateRequest> createRequests() {
+        return Lists.newArrayList(createRequest(KAKAO_ID, EMAIL, NAME), createRequest(KAKAO_ID2, EMAIL2, NAME2),
+            createRequest(KAKAO_ID3, EMAIL3, NAME3));
     }
 
     public static Member createWithoutId(final Long kakaoId, final String email, final String name) {

--- a/src/test/java/com/woowacourse/pelotonbackend/report/presentation/ReportControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/report/presentation/ReportControllerTest.java
@@ -102,6 +102,7 @@ class ReportControllerTest {
             .header(HttpHeaders.AUTHORIZATION, LoginFixture.getTokenHeader())
             .content(objectMapper.writeValueAsBytes(reportCreateRequest))
             .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isBadRequest())
+            .andDo(ReportDocumentation.createDuplicatedReport());
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/acceptance/RiderAcceptanceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/acceptance/RiderAcceptanceTest.java
@@ -3,13 +3,22 @@ package com.woowacourse.pelotonbackend.rider.acceptance;
 import static com.woowacourse.pelotonbackend.rider.domain.RiderFixture.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+import com.woowacourse.pelotonbackend.common.ErrorCode;
+import com.woowacourse.pelotonbackend.common.ErrorResponse;
 import com.woowacourse.pelotonbackend.member.domain.MemberFixture;
+import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
+import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponses;
 import com.woowacourse.pelotonbackend.rider.domain.RiderFixture;
 import com.woowacourse.pelotonbackend.rider.presentation.dto.RiderCreateRequest;
 import com.woowacourse.pelotonbackend.rider.presentation.dto.RiderResponse;
@@ -49,35 +58,82 @@ public class RiderAcceptanceTest extends AcceptanceTest {
     @DisplayName("Rider 관리 기능")
     @Test
     void manageRider() {
+        final List<MemberCreateRequest> members = MemberFixture.createRequests();
+        final List<JwtTokenResponse> tokenResponses = loginMembers(members);
         final RiderCreateRequest riderCreateRequest = RiderFixture.createMockRequest();
-        final JwtTokenResponse tokenResponse = loginMember(
-            MemberFixture.createRequest(MemberFixture.KAKAO_ID, MemberFixture.EMAIL, MemberFixture.NAME));
-        final MemberResponse memberResponse = requestFind(MemberFixture.KAKAO_ID);
-        final String resource = fetchCreateRider(tokenResponse, riderCreateRequest);
-        final RiderResponse riderResponse = fetchFindRider(resource, tokenResponse);
 
-        assertThat(riderResponse.getId()).isNotNull();
-        assertThat(riderResponse.getMemberId()).isEqualTo(memberResponse.getId());
-        assertThat(riderResponse.getRaceId()).isEqualTo(riderCreateRequest.getRaceId());
+        final Long raceId = riderCreateRequest.getRaceId();
+        final JwtTokenResponse tokenResponse = tokenResponses.get(0);
+        final MemberResponses memberResponses = findAllMembers(tokenResponse);
+        final MemberResponse memberResponse = memberResponses.getResponses().get(0);
+        final List<String> resources = fetchCreateRiders(tokenResponses, riderCreateRequest);
+        final String resource = resources.get(0);
+        final RiderResponses riderResponses = findAllRidersInRace(riderCreateRequest.getRaceId(), tokenResponse);
 
-        fetchCreateRiders(tokenResponse, riderCreateRequest);
-        fetchFindRidersByRaceId(TEST_RACE_ID, tokenResponse);
+        assertThat(riderResponses.getRiderResponses()).hasSize(RIDER_NUMBER);
+        assertThat(riderResponses.getRiderResponses()).extracting(RiderResponse::getMemberId)
+            .containsExactlyElementsOf(
+                memberResponses.getResponses().stream().map(MemberResponse::getId).collect(Collectors.toList()));
+        assertThat(riderResponses.getRiderResponses()).extracting(RiderResponse::getRaceId)
+            .allMatch(raceId::equals);
+
+        final ErrorResponse errorResponse = fetchCreateDuplicatedRider(tokenResponses.get(0), riderCreateRequest);
+
+        assertThat(errorResponse).extracting(ErrorResponse::getCode).isEqualTo(ErrorCode.RIDER_DUPLICATE.getCode());
+        assertThat(errorResponse).extracting(ErrorResponse::getMessage)
+            .isEqualTo(String.format("Rider(member id: %d, certification id: %d) already exists!",
+                memberResponse.getId(), riderCreateRequest.getRaceId()));
+
+        fetchFindRidersByRaceId(riderCreateRequest.getRaceId(), tokenResponse);
         fetchFindRidersByMemberId(memberResponse.getId(), tokenResponse);
 
         fetchUpdateRider(resource, tokenResponse);
-        final RiderResponse updatedRiderResponse = fetchFindRider(resource, tokenResponse);
-
-        assertThat(updatedRiderResponse.getMemberId()).isEqualTo((TEST_CHANGED_MEMBER_ID));
-        assertThat(updatedRiderResponse.getRaceId()).isEqualTo(TEST_CHANGED_RACE_ID);
+        fetchFindRider(resource, tokenResponse);
 
         fetchDeleteRider(resource, tokenResponse);
         fetchFindRiderFailed(resource, tokenResponse);
     }
 
-    private void fetchCreateRiders(final JwtTokenResponse tokenResponse, final RiderCreateRequest riderCreateRequest) {
-        for (int i = 0; i < RIDER_NUMBER; i++) {
-            fetchCreateRider(tokenResponse, riderCreateRequest);
+    private ErrorResponse fetchCreateDuplicatedRider(final JwtTokenResponse tokenResponse,
+        final RiderCreateRequest request) {
+
+        return given()
+            .header(createTokenHeader(tokenResponse))
+            .body(request)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/api/riders")
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .extract()
+            .as(ErrorResponse.class);
+    }
+
+    private RiderResponses findAllRidersInRace(final Long raceId,
+        final JwtTokenResponse tokenResponse) {
+
+        return given()
+            .header(createTokenHeader(tokenResponse))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/api/riders/races/{id}", raceId)
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .as(RiderResponses.class);
+    }
+
+    private List<String> fetchCreateRiders(final List<JwtTokenResponse> tokenResponses,
+        final RiderCreateRequest riderCreateRequest) {
+
+        final ArrayList<String> resources = Lists.newArrayList();
+
+        for (JwtTokenResponse tokenResponse : tokenResponses) {
+            resources.add(fetchCreateRider(tokenResponse, riderCreateRequest));
         }
+        return resources;
     }
 
     private void fetchFindRidersByRaceId(final Long raceId, final JwtTokenResponse tokenResponse) {
@@ -92,11 +148,11 @@ public class RiderAcceptanceTest extends AcceptanceTest {
             .body()
             .as(RiderResponses.class);
 
-        assertThat(riders.getRiderResponses().size()).isEqualTo(RIDER_NUMBER + 1);
+        assertThat(riders.getRiderResponses().size()).isEqualTo(RIDER_NUMBER);
     }
 
-    private RiderResponse fetchFindRider(final String resource, JwtTokenResponse tokenResponse) {
-        return given()
+    private void fetchFindRider(final String resource, JwtTokenResponse tokenResponse) {
+        final RiderResponse updatedRiderResponse = given()
             .header(createTokenHeader(tokenResponse))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .when()
@@ -106,6 +162,9 @@ public class RiderAcceptanceTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract()
             .as(RiderResponse.class);
+
+        assertThat(updatedRiderResponse.getMemberId()).isEqualTo((TEST_CHANGED_MEMBER_ID));
+        assertThat(updatedRiderResponse.getRaceId()).isEqualTo(TEST_CHANGED_RACE_ID);
     }
 
     private String fetchCreateRider(JwtTokenResponse tokenResponse, RiderCreateRequest request) {
@@ -134,7 +193,7 @@ public class RiderAcceptanceTest extends AcceptanceTest {
             .body()
             .as(RiderResponses.class);
 
-        assertThat(riders.getRiderResponses().size()).isEqualTo(RIDER_NUMBER + 1);
+        assertThat(riders.getRiderResponses().size()).isEqualTo(1L);
     }
 
     private void fetchUpdateRider(final String resource, final JwtTokenResponse tokenResponse) {

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/application/RiderServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/application/RiderServiceTest.java
@@ -89,6 +89,7 @@ public class RiderServiceTest {
         verify(riderRepository).deleteById(RiderFixture.TEST_RIDER_ID);
     }
 
+    @DisplayName("Rider 중복 생성 요청에 대해 예외를 반환한다.")
     @Test
     void createDuplicatedRider() {
         final MemberResponse memberResponse = MemberFixture.memberResponse();
@@ -98,9 +99,8 @@ public class RiderServiceTest {
         given(riderRepository.existsByMemberIdAndRaceID(memberResponse.getId(),
             riderCreateRequest.getRaceId())).willReturn(false, true);
         given(riderRepository.save(any(Rider.class))).willReturn(expectedRider);
-
-
         riderService.create(memberResponse, riderCreateRequest);
+
         assertThatThrownBy(() -> riderService.create(memberResponse, riderCreateRequest))
             .isInstanceOf(RiderDuplicatedException.class)
             .hasMessage("Rider(member id: %d, certification id: %d) already exists!",

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/domain/RiderFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/domain/RiderFixture.java
@@ -20,7 +20,7 @@ public class RiderFixture {
     public static final Long TEST_CHANGED_RACE_ID = 8L;
     public static final Long TEST_CHANGED_MEMBER_ID = 11L;
     public static final LocalDateTime TEST_CREATED_DATE_TIME = LocalDateTime.parse(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
-    public static final int RIDER_NUMBER = 4;
+    public static final int RIDER_NUMBER = 3;
 
     public static RiderCreateRequest createMockRequest() {
         return new RiderCreateRequest(TEST_RACE_ID);

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/domain/RiderRepositoryTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/domain/RiderRepositoryTest.java
@@ -76,4 +76,17 @@ public class RiderRepositoryTest {
         riders.forEach(
             rider -> assertThat(rider).isEqualToIgnoringGivenFields(riderWithoutId, "id", "createdAt", "updatedAt"));
     }
+
+    @DisplayName("멤버 id와 race id로 라이더를 조회한다.")
+    @Test
+    void existsByMemberIdAndRaceId() {
+        final Rider rider = createRiderBy(1L, 1L, null);
+
+        riderRepository.save(rider);
+        assertThat(riderRepository.existsByMemberIdAndRaceID(1L, 1L)).isTrue();
+
+        riderRepository.save(rider);
+        assertThatThrownBy(() -> riderRepository.existsByMemberIdAndRaceID(1L, 1L))
+            .isInstanceOf(AssertionError.class);
+    }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/domain/RiderRepositoryTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/domain/RiderRepositoryTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.validation.constraints.NotNull;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,16 +79,34 @@ public class RiderRepositoryTest {
             rider -> assertThat(rider).isEqualToIgnoringGivenFields(riderWithoutId, "id", "createdAt", "updatedAt"));
     }
 
-    @DisplayName("멤버 id와 race id로 라이더를 조회한다.")
+    @DisplayName("멤버 id와 레이스 id로 라이더가 존재하는 지 확인한다.")
     @Test
     void existsByMemberIdAndRaceId() {
-        final Rider rider = createRiderBy(1L, 1L, null);
-
+        final Rider rider = createRiderWithoutId();
         riderRepository.save(rider);
-        assertThat(riderRepository.existsByMemberIdAndRaceID(1L, 1L)).isTrue();
 
+        assertThat(riderRepository.existsByMemberIdAndRaceID(rider.getMemberId().getId(), rider.getRaceId().getId()))
+            .isTrue();
+    }
+
+    @DisplayName("멤버 id와 레이스 id로 라이더가 존재하지 않는 지 확인한다.")
+    @Test
+    void notExistsByMemberIdAndRaceId() {
+        assertThat(riderRepository.existsByMemberIdAndRaceID(1L, 1L)).isFalse();
+    }
+
+    @DisplayName("멤버 id와 race id로 중복된 라이더가 있을 때 예외를 반환한다.")
+    @Test
+    void existsDuplicatedByMemberIdAndRaceId() {
+        final Rider rider = createRiderWithoutId();
+        final Long memberId = rider.getMemberId().getId();
+        final Long raceId = rider.getRaceId().getId();
         riderRepository.save(rider);
-        assertThatThrownBy(() -> riderRepository.existsByMemberIdAndRaceID(1L, 1L))
-            .isInstanceOf(AssertionError.class);
+        riderRepository.save(rider);
+
+        assertThatThrownBy(() -> riderRepository.existsByMemberIdAndRaceID(memberId, raceId))
+            .isInstanceOf(AssertionError.class)
+            .hasMessage(String.format("There should not be duplicated (member_id, race_id), but (%d, %d)",
+                memberId, raceId));
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/RiderControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/RiderControllerTest.java
@@ -198,21 +198,13 @@ public class RiderControllerTest {
     @DisplayName("Rider 중복 생성 요청에 대해서 예외를 반환한다.")
     @Test
     void createDuplicatedRiderTest() throws Exception {
-        given(riderService.create(any(MemberResponse.class), any(RiderCreateRequest.class))).willReturn(TEST_RIDER_ID)
+        given(riderService.create(any(MemberResponse.class), any(RiderCreateRequest.class)))
             .willThrow(new RiderDuplicatedException(TEST_MEMBER_ID, TEST_RACE_ID));
         given(bearerAuthInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class),
             any(HandlerMethod.class))).willReturn(true);
         given(argumentResolver.resolveArgument(any(MethodParameter.class), any(ModelAndViewContainer.class),
             any(NativeWebRequest.class), any(WebDataBinderFactory.class))).willReturn(MemberFixture.memberResponse());
         given(argumentResolver.supportsParameter(any())).willReturn(true);
-
-        this.mockMvc.perform(post("/api/riders")
-            .header(HttpHeaders.AUTHORIZATION, LoginFixture.getTokenHeader())
-            .content(objectMapper.writeValueAsBytes(RiderFixture.createMockRequest()))
-            .contentType(MediaType.APPLICATION_JSON)
-        )
-            .andExpect(status().isCreated())
-            .andExpect(header().exists("Location"));
 
         this.mockMvc.perform(post("/api/riders")
             .header(HttpHeaders.AUTHORIZATION, LoginFixture.getTokenHeader())

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/RiderControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/RiderControllerTest.java
@@ -205,8 +205,6 @@ public class RiderControllerTest {
         given(argumentResolver.resolveArgument(any(MethodParameter.class), any(ModelAndViewContainer.class),
             any(NativeWebRequest.class), any(WebDataBinderFactory.class))).willReturn(MemberFixture.memberResponse());
         given(argumentResolver.supportsParameter(any())).willReturn(true);
-        // given(globalExceptionHandler.businessException(any(BusinessException.class))).willReturn(
-        //     ResponseEntity.badRequest().body(ErrorResponse.of(400, "Rider-002", "")));
 
         this.mockMvc.perform(post("/api/riders")
             .header(HttpHeaders.AUTHORIZATION, LoginFixture.getTokenHeader())


### PR DESCRIPTION
Certification, Report, Rider의 중복 생성요청에 대한 방어로직 구현했습니다.

resolves #226 