### PR TITLE
fix: 회원 가입 시 카카오 프로필 사진을 불러오지 않던 문제 해결

### DIFF
--- a/peloton-frontend/component/LoginNavigationRoot.js
+++ b/peloton-frontend/component/LoginNavigationRoot.js
@@ -15,7 +15,7 @@ const LoginNavigationRoot = () => {
         options={{ headerShown: false }}
       />
       <LoginStack.Screen
-        name="ChangeNickname"
+        name="ChangeProfile"
         component={ChangeProfile}
         options={{ headerShown: false }}
       />

--- a/peloton-frontend/component/login/ChangeProfile.js
+++ b/peloton-frontend/component/login/ChangeProfile.js
@@ -77,8 +77,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   title: {
-    width: 150,
-    height: 41,
     fontSize: 28,
     fontWeight: "100",
     fontStyle: "normal",

--- a/peloton-frontend/component/login/ChangeProfile.js
+++ b/peloton-frontend/component/login/ChangeProfile.js
@@ -17,7 +17,7 @@ import NicknameInput from "./NicknameInput";
 import { navigateWithoutHistory } from "../../utils/util";
 import LoadingIndicator from "../../utils/LoadingIndicator";
 import { loadingState } from "../../state/loading/LoadingState";
-import { memberInfoState, memberTokenState } from "../../state/member/MemberState";
+import { memberInfoState, memberTokenState, } from "../../state/member/MemberState";
 import { MemberApi } from "../../utils/api/MemberApi";
 
 const ChangeProfile = () => {
@@ -88,9 +88,6 @@ const styles = StyleSheet.create({
   body: {
     flex: 7,
     alignItems: "center",
-    borderStyle: "solid",
-    borderBottomWidth: 2,
-    borderColor: COLOR.BLUE5,
   },
 });
 

--- a/peloton-frontend/component/login/KakaoLoginWebView.js
+++ b/peloton-frontend/component/login/KakaoLoginWebView.js
@@ -22,18 +22,18 @@ const KakaoLoginWebView = ({ toggleModal }) => {
       return;
     }
     url
-    .split("?")[1]
-    .split("&")
-    .forEach((param) => {
-      const key = param.split("=")[0];
-      if (key === "access_token") {
-        accessToken = param.split("=")[1];
-      } else if (key === "is_created") {
-        isCreated = param.split("=")[1];
-      } else if (key === "success") {
-        success = param.split("=")[1];
-      }
-    });
+      .split("?")[1]
+      .split("&")
+      .forEach((param) => {
+        const key = param.split("=")[0];
+        if (key === "access_token") {
+          accessToken = param.split("=")[1];
+        } else if (key === "is_created") {
+          isCreated = param.split("=")[1];
+        } else if (key === "success") {
+          success = param.split("=")[1];
+        }
+      });
     if (!success) {
       console.log("login Fail");
       toggleModal();
@@ -43,7 +43,7 @@ const KakaoLoginWebView = ({ toggleModal }) => {
       toggleModal();
       setToken(accessToken);
       if (isCreated === "true") {
-        navigation.navigate("ChangeNickname");
+        navigation.navigate("ChangeProfile");
       } else {
         navigateWithoutHistory(navigation, "ApplicationNavigationRoot");
       }

--- a/peloton-frontend/component/login/ProfileImageSelect.js
+++ b/peloton-frontend/component/login/ProfileImageSelect.js
@@ -29,6 +29,7 @@ const ProfileImageSelect = () => {
 const styles = StyleSheet.create({
   container: {
     paddingBottom: 130,
+    minHeight: 120,
   },
   profileImage: {
     height: 120,

--- a/peloton-frontend/component/login/ProfileImageSelect.js
+++ b/peloton-frontend/component/login/ProfileImageSelect.js
@@ -3,8 +3,7 @@ import { Image, StyleSheet, View } from "react-native";
 import ProfileImageEditButton from "../profile/ProfileImageEditButton";
 import { useRecoilValue } from "recoil";
 import { memberInfoState } from "../../state/member/MemberState";
-import ProfileImageEditIcon from "../profile/profileedit/ProfileImageEditIcon";
-import { COLOR } from "../../utils/constants";
+import CameraIcon from "../profile/profileedit/CameraIcon";
 
 const ProfileImageSelect = () => {
   const memberInfo = useRecoilValue(memberInfoState);
@@ -21,7 +20,7 @@ const ProfileImageSelect = () => {
           }
           defaultSource={require("../../assets/default-profile.jpg")}
         />
-        <ProfileImageEditIcon />
+        <CameraIcon />
       </ProfileImageEditButton>
     </View>
   );
@@ -29,24 +28,12 @@ const ProfileImageSelect = () => {
 
 const styles = StyleSheet.create({
   container: {
-    height: 250,
+    paddingBottom: 130,
   },
   profileImage: {
     height: 120,
     width: 120,
     borderRadius: 60,
-  },
-  cameraIcon: {
-    opacity: 0.7,
-    alignItems: "center",
-    justifyContent: "center",
-    width: 30,
-    height: 30,
-    borderRadius: 15,
-    backgroundColor: COLOR.WHITE,
-    position: "absolute",
-    top: 85,
-    left: 85,
   },
 });
 

--- a/peloton-frontend/component/profile/ProfileEditButton.js
+++ b/peloton-frontend/component/profile/ProfileEditButton.js
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   buttonText: {
-    color: COLOR.GREEN2,
+    color: COLOR.WHITE,
     fontSize: 14,
   },
 });

--- a/peloton-frontend/component/profile/profileedit/CameraIcon.js
+++ b/peloton-frontend/component/profile/profileedit/CameraIcon.js
@@ -21,8 +21,8 @@ const styles = StyleSheet.create({
     borderRadius: 15,
     backgroundColor: COLOR.WHITE,
     position: "absolute",
-    marginTop: 90,
-    alignSelf: "flex-end",
+    bottom: 0,
+    right: 0,
   },
 });
 

--- a/peloton-frontend/component/profile/profileedit/CameraIcon.js
+++ b/peloton-frontend/component/profile/profileedit/CameraIcon.js
@@ -3,7 +3,7 @@ import { StyleSheet, View } from "react-native";
 import { Entypo } from "@expo/vector-icons";
 import { COLOR } from "../../../utils/constants";
 
-const ProfileImageEditIcon = () => {
+const CameraIcon = () => {
   return (
     <View style={styles.cameraIcon}>
       <Entypo name="camera" size={24} color="black" />
@@ -21,9 +21,9 @@ const styles = StyleSheet.create({
     borderRadius: 15,
     backgroundColor: COLOR.WHITE,
     position: "absolute",
-    top: 70,
-    left: 70,
+    marginTop: 90,
+    alignSelf: "flex-end",
   },
 });
 
-export default ProfileImageEditIcon;
+export default CameraIcon;

--- a/peloton-frontend/component/profile/profileedit/CashUpdate.js
+++ b/peloton-frontend/component/profile/profileedit/CashUpdate.js
@@ -42,7 +42,7 @@ const CashUpdate = () => {
   };
 
   const requestChangeCash = async () => {
-    if (validateCash(cash)) {
+    if (!validateCash(cash)) {
       Alert.alert("충전 금액을 다시 입력해주세요.");
       return;
     }

--- a/peloton-frontend/component/profile/profileedit/ProfileImageEdit.js
+++ b/peloton-frontend/component/profile/profileedit/ProfileImageEdit.js
@@ -2,14 +2,14 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import ProfileImageEditButton from "../ProfileImageEditButton";
 import ProfileImage from "../ProfileImage";
-import ProfileImageEditIcon from "./ProfileImageEditIcon";
+import CameraIcon from "./CameraIcon";
 
 const ProfileImageEdit = () => {
   return (
     <View style={styles.imageContainer}>
       <ProfileImageEditButton>
         <ProfileImage />
-        <ProfileImageEditIcon />
+        <CameraIcon />
       </ProfileImageEditButton>
     </View>
   );

--- a/src/main/java/com/woowacourse/pelotonbackend/member/application/LoginService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/application/LoginService.java
@@ -1,14 +1,22 @@
 package com.woowacourse.pelotonbackend.member.application;
 
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.pelotonbackend.infra.login.LoginAPIService;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoTokenResponse;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
+import com.woowacourse.pelotonbackend.member.domain.Role;
+import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.support.JwtTokenProvider;
+import com.woowacourse.pelotonbackend.support.RandomGenerator;
 import com.woowacourse.pelotonbackend.support.dto.JwtTokenResponse;
+import com.woowacourse.pelotonbackend.vo.Cash;
+import com.woowacourse.pelotonbackend.vo.ImageUrl;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +30,10 @@ public class LoginService {
     private final LoginAPIService<KakaoTokenResponse, KakaoUserResponse> kakaoAPIService;
     private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RandomGenerator randomGenerator;
+
+    @Value("${cloud.aws.s3.basic-profile-url}")
+    private String basicProfileUrl;
 
     public String createCodeUrl() {
         return kakaoAPIService.getCodeUrl();
@@ -40,9 +52,17 @@ public class LoginService {
                 NOT_CREATED);
         }
 
-        MemberResponse memberResponse = memberService.createByLoginApiUser(kakaoUserResponse);
+        final MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+            .email(kakaoUserResponse.getEmail())
+            .cash(Cash.initial())
+            .kakaoId(kakaoUserResponse.getId())
+            .name(kakaoUserResponse.getNickname() + randomGenerator.getRandomString())
+            .profile(new ImageUrl(Optional.ofNullable(kakaoUserResponse.getProfileImage()).orElse(basicProfileUrl)))
+            .role(Role.MEMBER)
+            .build();
 
         return JwtTokenResponse.of(
-            jwtTokenProvider.createToken(memberResponse.getKakaoId().toString()), CREATED);
+            jwtTokenProvider.createToken(
+                memberService.createMember(memberCreateRequest).getKakaoId().toString()), CREATED);
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/member/application/LoginService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/application/LoginService.java
@@ -17,10 +17,7 @@ import com.woowacourse.pelotonbackend.support.RandomGenerator;
 import com.woowacourse.pelotonbackend.support.dto.JwtTokenResponse;
 import com.woowacourse.pelotonbackend.vo.Cash;
 import com.woowacourse.pelotonbackend.vo.ImageUrl;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 @Service
 @Transactional
 public class LoginService {
@@ -31,9 +28,20 @@ public class LoginService {
     private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RandomGenerator randomGenerator;
+    private final String basicProfileUrl;
 
-    @Value("${cloud.aws.s3.basic-profile-url}")
-    private String basicProfileUrl;
+    public LoginService(
+        final LoginAPIService<KakaoTokenResponse, KakaoUserResponse> kakaoAPIService,
+        final MemberService memberService,
+        final JwtTokenProvider jwtTokenProvider,
+        final RandomGenerator randomGenerator,
+        @Value("${cloud.aws.s3.basic-profile-url}") final String basicProfileUrl) {
+        this.kakaoAPIService = kakaoAPIService;
+        this.memberService = memberService;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.randomGenerator = randomGenerator;
+        this.basicProfileUrl = basicProfileUrl;
+    }
 
     public String createCodeUrl() {
         return kakaoAPIService.getCodeUrl();

--- a/src/main/java/com/woowacourse/pelotonbackend/member/application/LoginService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/application/LoginService.java
@@ -6,14 +6,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.woowacourse.pelotonbackend.infra.login.LoginAPIService;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoTokenResponse;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
-import com.woowacourse.pelotonbackend.member.domain.Role;
-import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.support.JwtTokenProvider;
-import com.woowacourse.pelotonbackend.support.RandomGenerator;
 import com.woowacourse.pelotonbackend.support.dto.JwtTokenResponse;
-import com.woowacourse.pelotonbackend.vo.Cash;
-import com.woowacourse.pelotonbackend.vo.ImageUrl;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +22,6 @@ public class LoginService {
     private final LoginAPIService<KakaoTokenResponse, KakaoUserResponse> kakaoAPIService;
     private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final RandomGenerator randomGenerator;
 
     public String createCodeUrl() {
         return kakaoAPIService.getCodeUrl();
@@ -45,16 +39,10 @@ public class LoginService {
             return JwtTokenResponse.of(jwtTokenProvider.createToken(memberResponse.getKakaoId().toString()),
                 NOT_CREATED);
         }
-        final MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
-            .email(kakaoUserResponse.getEmail())
-            .cash(Cash.initial())
-            .kakaoId(kakaoUserResponse.getId())
-            .name(kakaoUserResponse.getNickname() + randomGenerator.getRandomString())
-            .profile(new ImageUrl(kakaoUserResponse.getProfileImage()))
-            .role(Role.MEMBER)
-            .build();
+
+        MemberResponse memberResponse = memberService.createByLoginApiUser(kakaoUserResponse);
+
         return JwtTokenResponse.of(
-            jwtTokenProvider.createToken(
-                memberService.createMember(memberCreateRequest).getKakaoId().toString()), CREATED);
+            jwtTokenProvider.createToken(memberResponse.getKakaoId().toString()), CREATED);
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/member/application/MemberService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/application/MemberService.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.member.application;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.validation.Valid;
 
@@ -11,19 +10,15 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.woowacourse.pelotonbackend.common.exception.MemberNotFoundException;
-import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
 import com.woowacourse.pelotonbackend.infra.upload.UploadService;
 import com.woowacourse.pelotonbackend.member.domain.Member;
 import com.woowacourse.pelotonbackend.member.domain.MemberRepository;
-import com.woowacourse.pelotonbackend.member.domain.Role;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCashUpdateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberNameUpdateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberProfileResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponses;
-import com.woowacourse.pelotonbackend.support.RandomGenerator;
-import com.woowacourse.pelotonbackend.vo.Cash;
 import com.woowacourse.pelotonbackend.vo.ImageUrl;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -32,29 +27,13 @@ import lombok.AllArgsConstructor;
 @Service
 @Transactional
 public class MemberService {
-    private static final String BASIC_PROFILE_URL = "https://14f-guys-image.s3.ap-northeast-2.amazonaws.com/basic.profile.image.png";
-
     private final MemberRepository memberRepository;
     private final UploadService uploadService;
-    private final RandomGenerator randomGenerator;
 
     public MemberResponse createMember(final @Valid MemberCreateRequest memberCreateRequest) {
         final Member persistMember = memberRepository.save(memberCreateRequest.toMember());
 
         return MemberResponse.from(persistMember);
-    }
-
-    public MemberResponse createByLoginApiUser(final @Valid KakaoUserResponse kakaoUserResponse) {
-        final MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
-            .email(kakaoUserResponse.getEmail())
-            .cash(Cash.initial())
-            .kakaoId(kakaoUserResponse.getId())
-            .name(kakaoUserResponse.getNickname() + randomGenerator.getRandomString())
-            .profile(new ImageUrl(Optional.ofNullable(kakaoUserResponse.getProfileImage()).orElse(BASIC_PROFILE_URL)))
-            .role(Role.MEMBER)
-            .build();
-
-        return createMember(memberCreateRequest);
     }
 
     @Transactional(readOnly = true)
@@ -86,6 +65,15 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    public MemberResponse findByKakaoId(final Long kakaoId) {
+        final Member member = memberRepository.findByKakaoId(kakaoId)
+            .orElseThrow(
+                () -> new MemberNotFoundException(
+                    String.format("Member(member kakaoId = %d) does not exist", kakaoId)));
+        return MemberResponse.from(member);
+    }
+
+    @Transactional(readOnly = true)
     public boolean existsByKakaoId(final Long kakaoId) {
         return memberRepository.existsByKakaoId(kakaoId);
     }
@@ -106,6 +94,7 @@ public class MemberService {
         return MemberResponse.from(persist);
     }
 
+<<<<<<< HEAD
     public void minusCash(final Long id, final Cash cash) {
         final Member member = findMemberById(id);
         final Member updatedMember = member.minusCash(cash);
@@ -121,6 +110,8 @@ public class MemberService {
             .orElseThrow(() -> new MemberNotFoundException(id));
     }
 
+=======
+>>>>>>> feat: config 설정에 기본 프로필 이미지 url 추가, 리뷰 반영
     public MemberProfileResponse updateProfileImage(final Long memberId, final MultipartFile file) {
         final Member member = findMemberById(memberId);
 
@@ -134,5 +125,14 @@ public class MemberService {
         memberRepository.save(updatedMember);
 
         return new MemberProfileResponse(changedProfileUrl);
+    }
+
+    private Member findMemberById(final Long id) {
+        return memberRepository.findById(id)
+            .orElseThrow(() -> new MemberNotFoundException(id));
+    }
+
+    public void deleteById(final Long id) {
+        memberRepository.deleteById(id);
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/member/application/MemberService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/application/MemberService.java
@@ -2,6 +2,7 @@ package com.woowacourse.pelotonbackend.member.application;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.validation.Valid;
 
@@ -10,15 +11,18 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.woowacourse.pelotonbackend.common.exception.MemberNotFoundException;
+import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
 import com.woowacourse.pelotonbackend.infra.upload.UploadService;
 import com.woowacourse.pelotonbackend.member.domain.Member;
 import com.woowacourse.pelotonbackend.member.domain.MemberRepository;
+import com.woowacourse.pelotonbackend.member.domain.Role;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCashUpdateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberNameUpdateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberProfileResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponses;
+import com.woowacourse.pelotonbackend.support.RandomGenerator;
 import com.woowacourse.pelotonbackend.vo.Cash;
 import com.woowacourse.pelotonbackend.vo.ImageUrl;
 import lombok.AccessLevel;
@@ -28,15 +32,29 @@ import lombok.AllArgsConstructor;
 @Service
 @Transactional
 public class MemberService {
-    private static final String BASIC_URL = "https://14f-guys-image.s3.ap-northeast-2.amazonaws.com/basic.profile.image.png";
+    private static final String BASIC_PROFILE_URL = "https://14f-guys-image.s3.ap-northeast-2.amazonaws.com/basic.profile.image.png";
 
     private final MemberRepository memberRepository;
     private final UploadService uploadService;
+    private final RandomGenerator randomGenerator;
 
     public MemberResponse createMember(final @Valid MemberCreateRequest memberCreateRequest) {
         final Member persistMember = memberRepository.save(memberCreateRequest.toMember());
 
         return MemberResponse.from(persistMember);
+    }
+
+    public MemberResponse createByLoginApiUser(final @Valid KakaoUserResponse kakaoUserResponse) {
+        final MemberCreateRequest memberCreateRequest = MemberCreateRequest.builder()
+            .email(kakaoUserResponse.getEmail())
+            .cash(Cash.initial())
+            .kakaoId(kakaoUserResponse.getId())
+            .name(kakaoUserResponse.getNickname() + randomGenerator.getRandomString())
+            .profile(new ImageUrl(Optional.ofNullable(kakaoUserResponse.getProfileImage()).orElse(BASIC_PROFILE_URL)))
+            .role(Role.MEMBER)
+            .build();
+
+        return createMember(memberCreateRequest);
     }
 
     @Transactional(readOnly = true)
@@ -105,7 +123,12 @@ public class MemberService {
 
     public MemberProfileResponse updateProfileImage(final Long memberId, final MultipartFile file) {
         final Member member = findMemberById(memberId);
-        final String changedProfileUrl = Objects.isNull(file) ? BASIC_URL : uploadService.uploadImage(file, "member.profile.image/");
+
+        if (Objects.isNull(file)) {
+            return new MemberProfileResponse(member.getProfile().getBaseImageUrl());
+        }
+
+        final String changedProfileUrl = uploadService.uploadImage(file, "member.profile.image/");
         final Member updatedMember = member.changeProfile(new ImageUrl(changedProfileUrl));
 
         memberRepository.save(updatedMember);

--- a/src/main/java/com/woowacourse/pelotonbackend/member/application/MemberService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/application/MemberService.java
@@ -19,6 +19,7 @@ import com.woowacourse.pelotonbackend.member.presentation.dto.MemberNameUpdateRe
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberProfileResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponses;
+import com.woowacourse.pelotonbackend.vo.Cash;
 import com.woowacourse.pelotonbackend.vo.ImageUrl;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,13 +41,6 @@ public class MemberService {
     public MemberResponse findMember(final Long id) {
         final Member member = findMemberById(id);
 
-        return MemberResponse.from(member);
-    }
-
-    public MemberResponse findByKakaoId(final Long kakaoId) {
-        final Member member = memberRepository.findByKakaoId(kakaoId)
-            .orElseThrow(
-                () -> new MemberNotFoundException(String.format("Member(member kakaoId = %d) does not exist", kakaoId)));
         return MemberResponse.from(member);
     }
 
@@ -94,24 +88,12 @@ public class MemberService {
         return MemberResponse.from(persist);
     }
 
-<<<<<<< HEAD
     public void minusCash(final Long id, final Cash cash) {
         final Member member = findMemberById(id);
         final Member updatedMember = member.minusCash(cash);
         memberRepository.save(updatedMember);
     }
 
-    public void deleteById(final Long id) {
-        memberRepository.deleteById(id);
-    }
-
-    private Member findMemberById(final Long id) {
-        return memberRepository.findById(id)
-            .orElseThrow(() -> new MemberNotFoundException(id));
-    }
-
-=======
->>>>>>> feat: config 설정에 기본 프로필 이미지 url 추가, 리뷰 반영
     public MemberProfileResponse updateProfileImage(final Long memberId, final MultipartFile file) {
         final Member member = findMemberById(memberId);
 

--- a/src/main/java/com/woowacourse/pelotonbackend/member/domain/Member.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/domain/Member.java
@@ -33,7 +33,7 @@ public class Member {
     @NotNull
     private final Long kakaoId;
 
-    @NotNull
+    @NotNull @Valid
     @Embedded(prefix = "PROFILE_", onEmpty = Embedded.OnEmpty.USE_EMPTY)
     private final ImageUrl profile;
 

--- a/src/main/java/com/woowacourse/pelotonbackend/member/domain/Member.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/domain/Member.java
@@ -33,6 +33,7 @@ public class Member {
     @NotNull
     private final Long kakaoId;
 
+    @NotNull
     @Embedded(prefix = "PROFILE_", onEmpty = Embedded.OnEmpty.USE_EMPTY)
     private final ImageUrl profile;
 

--- a/src/main/resources/db/changelog-master.xml
+++ b/src/main/resources/db/changelog-master.xml
@@ -8,4 +8,5 @@
     <include file="./changes/changelog-schema-1.0.2.xml" relativeToChangelogFile="true"/>
     <include file="./changes/changelog-schema-1.0.3.xml" relativeToChangelogFile="true"/>
     <include file="./changes/changelog-schema-1.0.4.xml" relativeToChangelogFile="true"/>
+    <include file="./changes/changelog-schema-1.0.5.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changes/changelog-schema-1.0.5.xml
+++ b/src/main/resources/db/changes/changelog-schema-1.0.5.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="moonui" id="20200817">
+        <addNotNullConstraint tableName="MEMBER" columnName="PROFILE_BASE_IMAGE_URL" columnDataType="CLOB" defaultNullValue="https://14f-guys-image.s3.ap-northeast-2.amazonaws.com/basic.profile.image.png"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/java/com/woowacourse/pelotonbackend/member/application/LoginServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/application/LoginServiceTest.java
@@ -14,7 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.woowacourse.pelotonbackend.infra.login.LoginAPIService;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoTokenResponse;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
+import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.support.JwtTokenProvider;
+import com.woowacourse.pelotonbackend.support.RandomGenerator;
 import com.woowacourse.pelotonbackend.support.dto.JwtTokenResponse;
 import reactor.core.publisher.Mono;
 
@@ -31,9 +33,12 @@ class LoginServiceTest {
     @Mock
     private JwtTokenProvider jwtTokenProvider;
 
+    @Mock
+    private RandomGenerator randomGenerator;
+
     @BeforeEach
     void setUp() {
-        loginService = new LoginService(kakaoAPIService, memberService, jwtTokenProvider);
+        loginService = new LoginService(kakaoAPIService, memberService, jwtTokenProvider, randomGenerator);
     }
 
     @DisplayName("CodeUrl을 요청하면 kakaoAPI에서 CodeUrl을 받아서 반환한다.")
@@ -66,7 +71,8 @@ class LoginServiceTest {
         when(kakaoAPIService.fetchUserInfo(any(KakaoTokenResponse.class))).thenReturn(
             Mono.just(createMockKakaoUserResponse()));
         when(memberService.existsByKakaoId(anyLong())).thenReturn(false);
-        when(memberService.createByLoginApiUser(any(KakaoUserResponse.class))).thenReturn(createMockMemberResponse());
+        when(randomGenerator.getRandomString()).thenReturn(NICKNAME);
+        when(memberService.createMember(any(MemberCreateRequest.class))).thenReturn(createMockMemberResponse());
         when(jwtTokenProvider.createToken(anyString())).thenReturn(TOKEN);
 
         assertThat(loginService.createJwtTokenUrl(CODE_VALUE)).isEqualTo(URL);

--- a/src/test/java/com/woowacourse/pelotonbackend/member/application/LoginServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/application/LoginServiceTest.java
@@ -14,9 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.woowacourse.pelotonbackend.infra.login.LoginAPIService;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoTokenResponse;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
-import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.support.JwtTokenProvider;
-import com.woowacourse.pelotonbackend.support.RandomGenerator;
 import com.woowacourse.pelotonbackend.support.dto.JwtTokenResponse;
 import reactor.core.publisher.Mono;
 
@@ -33,12 +31,9 @@ class LoginServiceTest {
     @Mock
     private JwtTokenProvider jwtTokenProvider;
 
-    @Mock
-    private RandomGenerator randomGenerator;
-
     @BeforeEach
     void setUp() {
-        loginService = new LoginService(kakaoAPIService, memberService, jwtTokenProvider, randomGenerator);
+        loginService = new LoginService(kakaoAPIService, memberService, jwtTokenProvider);
     }
 
     @DisplayName("CodeUrl을 요청하면 kakaoAPI에서 CodeUrl을 받아서 반환한다.")
@@ -71,8 +66,7 @@ class LoginServiceTest {
         when(kakaoAPIService.fetchUserInfo(any(KakaoTokenResponse.class))).thenReturn(
             Mono.just(createMockKakaoUserResponse()));
         when(memberService.existsByKakaoId(anyLong())).thenReturn(false);
-        when(randomGenerator.getRandomString()).thenReturn(NICKNAME);
-        when(memberService.createMember(any(MemberCreateRequest.class))).thenReturn(createMockMemberResponse());
+        when(memberService.createByLoginApiUser(any(KakaoUserResponse.class))).thenReturn(createMockMemberResponse());
         when(jwtTokenProvider.createToken(anyString())).thenReturn(TOKEN);
 
         assertThat(loginService.createJwtTokenUrl(CODE_VALUE)).isEqualTo(URL);

--- a/src/test/java/com/woowacourse/pelotonbackend/member/application/LoginServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/application/LoginServiceTest.java
@@ -38,7 +38,8 @@ class LoginServiceTest {
 
     @BeforeEach
     void setUp() {
-        loginService = new LoginService(kakaoAPIService, memberService, jwtTokenProvider, randomGenerator);
+        loginService = new LoginService(kakaoAPIService, memberService, jwtTokenProvider, randomGenerator,
+            BASIC_PROFILE_URL);
     }
 
     @DisplayName("CodeUrl을 요청하면 kakaoAPI에서 CodeUrl을 받아서 반환한다.")

--- a/src/test/java/com/woowacourse/pelotonbackend/member/application/MemberServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/application/MemberServiceTest.java
@@ -31,12 +31,7 @@ import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateReques
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberProfileResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponses;
-<<<<<<< HEAD
 import com.woowacourse.pelotonbackend.vo.Cash;
-import com.woowacourse.pelotonbackend.support.RandomGenerator;
-import com.woowacourse.pelotonbackend.vo.ImageUrl;
-=======
->>>>>>> feat: config 설정에 기본 프로필 이미지 url 추가, 리뷰 반영
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -47,8 +42,6 @@ class MemberServiceTest {
 
     @Mock
     private UploadService uploadService;
-
-    private String basicProfileUrl;
 
     private Member expectedMember;
 

--- a/src/test/java/com/woowacourse/pelotonbackend/member/application/MemberServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/application/MemberServiceTest.java
@@ -23,9 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.woowacourse.pelotonbackend.common.exception.MemberNotFoundException;
 import com.woowacourse.pelotonbackend.common.exception.UploadFailureException;
-import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
 import com.woowacourse.pelotonbackend.infra.upload.UploadService;
-import com.woowacourse.pelotonbackend.member.domain.LoginFixture;
 import com.woowacourse.pelotonbackend.member.domain.Member;
 import com.woowacourse.pelotonbackend.member.domain.MemberFixture;
 import com.woowacourse.pelotonbackend.member.domain.MemberRepository;
@@ -33,9 +31,12 @@ import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateReques
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberProfileResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponses;
+<<<<<<< HEAD
 import com.woowacourse.pelotonbackend.vo.Cash;
 import com.woowacourse.pelotonbackend.support.RandomGenerator;
 import com.woowacourse.pelotonbackend.vo.ImageUrl;
+=======
+>>>>>>> feat: config 설정에 기본 프로필 이미지 url 추가, 리뷰 반영
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -47,14 +48,13 @@ class MemberServiceTest {
     @Mock
     private UploadService uploadService;
 
-    @Mock
-    private RandomGenerator randomGenerator;
+    private String basicProfileUrl;
 
     private Member expectedMember;
 
     @BeforeEach
     void setUp() {
-        memberService = new MemberService(memberRepository, uploadService, randomGenerator);
+        memberService = new MemberService(memberRepository, uploadService);
         expectedMember = createWithId(MEMBER_ID);
     }
 
@@ -67,39 +67,6 @@ class MemberServiceTest {
         final MemberResponse response = memberService.createMember(memberCreateRequest);
 
         assertThat(response).isEqualToIgnoringGivenFields(expectedMember, "createdAt", "updatedAt");
-    }
-
-    @DisplayName("로그인 API를 통해 불러온 회원정보로 회원을 생성한다")
-    @Test
-    void createByLoginApiUser_Test() {
-        final String appendingString = "12345";
-        KakaoUserResponse kakaoUserResponse = LoginFixture.createKakaoUserResponseWithNullProfile();
-        given(randomGenerator.getRandomString()).willReturn(appendingString);
-        Member memberWithBasicProfile = expectedMember.toBuilder()
-            .name(expectedMember.getName() + appendingString)
-            .profile(new ImageUrl(BASIC_PROFILE_URL))
-            .build();
-        given(memberRepository.save(any(Member.class))).willReturn(memberWithBasicProfile);
-
-        final MemberResponse response = memberService.createByLoginApiUser(kakaoUserResponse);
-
-        assertThat(response).isEqualToIgnoringGivenFields(memberWithBasicProfile, "createdAt", "updatedAt");
-    }
-
-    @DisplayName("로그인 API를 통해 불러온 회원정보의 프로필 이미지가 null일 때 기본 프로필 이미지로 회원을 생성한다")
-    @Test
-    void createByLoginApiUser_WithNullProfile_Test() {
-        final String appendingString = "12345";
-        KakaoUserResponse kakaoUserResponse = LoginFixture.createMockKakaoUserResponse();
-        given(randomGenerator.getRandomString()).willReturn(appendingString);
-        Member memberWithAppendedName = expectedMember.toBuilder()
-            .name(expectedMember.getName() + appendingString)
-            .build();
-        given(memberRepository.save(any(Member.class))).willReturn(memberWithAppendedName);
-
-        final MemberResponse response = memberService.createByLoginApiUser(kakaoUserResponse);
-
-        assertThat(response).isEqualToIgnoringGivenFields(memberWithAppendedName, "createdAt", "updatedAt");
     }
 
     @DisplayName("회원을 조회한다.")

--- a/src/test/java/com/woowacourse/pelotonbackend/member/domain/LoginFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/domain/LoginFixture.java
@@ -77,25 +77,6 @@ public class LoginFixture {
             .build();
     }
 
-    public static KakaoUserResponse createKakaoUserResponseWithNullProfile() {
-        return KakaoUserResponse.builder()
-            .id(KAKAO_ID)
-            .nickname(NICKNAME)
-            .profileImage(null)
-            .thumbnailImage(URL)
-            .hasEmail(ADMIT)
-            .emailValid(!ADMIT)
-            .emailVerified(!ADMIT)
-            .email(EMAIL)
-            .emailNeedsAgreement(ADMIT)
-            .hasBirthday(ADMIT)
-            .birthdayNeedsAgreement(ADMIT)
-            .birthday(BIRTHDAY)
-            .hasGender(ADMIT)
-            .genderNeedsAgreement(ADMIT)
-            .build();
-    }
-
     public static MemberResponse createMockMemberResponse() {
         return MemberResponse.builder()
             .kakaoId(KAKAO_ID)

--- a/src/test/java/com/woowacourse/pelotonbackend/member/domain/LoginFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/domain/LoginFixture.java
@@ -77,6 +77,25 @@ public class LoginFixture {
             .build();
     }
 
+    public static KakaoUserResponse createKakaoUserResponseWithNullProfile() {
+        return KakaoUserResponse.builder()
+            .id(KAKAO_ID)
+            .nickname(NICKNAME)
+            .profileImage(null)
+            .thumbnailImage(URL)
+            .hasEmail(ADMIT)
+            .emailValid(!ADMIT)
+            .emailVerified(!ADMIT)
+            .email(EMAIL)
+            .emailNeedsAgreement(ADMIT)
+            .hasBirthday(ADMIT)
+            .birthdayNeedsAgreement(ADMIT)
+            .birthday(BIRTHDAY)
+            .hasGender(ADMIT)
+            .genderNeedsAgreement(ADMIT)
+            .build();
+    }
+
     public static MemberResponse createMockMemberResponse() {
         return MemberResponse.builder()
             .kakaoId(KAKAO_ID)

--- a/src/test/java/com/woowacourse/pelotonbackend/member/domain/LoginFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/domain/LoginFixture.java
@@ -22,11 +22,9 @@ public class LoginFixture {
     public static final String CLIENT_SECRET_VALUE = "SECRET";
     public static final String RESPONSE_TYPE_VALUE = "RESPONSE";
     public static final String GRANT_TYPE_VALUE = "code";
-    public static final String GRANT_TYPE = "GRANT_TYPE";
     public static final String AUTHORIZE_PATH = "/oauth/authorize";
     public static final String RESPONSE_TYPE = "response_type";
     public static final String CLIENT_ID = "client_id";
-    public static final String CLIENT_SECRET = "client_secret";
     public static final String REDIRECT_URI = "redirect_uri";
     public static final String REDIRECT_PATH = "/api/login/token";
     public static final String OAUTH_TOKEN_PATH = "/oauth/token";
@@ -41,6 +39,7 @@ public class LoginFixture {
     public static final String BIRTHDAY = "0429";
     public static final int EXPIRE = 1;
     public static final boolean ADMIT = true;
+    public static final String BASIC_PROFILE_URL= "https://14f-guys-image.s3.ap-northeast-2.amazonaws.com/basic.profile.image.png";
 
     public static class TestController {
         public void testMethod(@LoginMember Member member) {

--- a/src/test/java/com/woowacourse/pelotonbackend/member/domain/MemberFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/domain/MemberFixture.java
@@ -32,7 +32,6 @@ public class MemberFixture {
     public static final Long MEMBER_ID = 1L;
     public static final Long MEMBER_ID2 = 2L;
     public static final Long MEMBER_ID3 = 3L;
-    public static final Long NOT_EXIST_ID = 100L;
     public static final Long KAKAO_ID = 1L;
     public static final Long KAKAO_ID2 = 2L;
     public static final Long KAKAO_ID3 = 3L;
@@ -135,7 +134,8 @@ public class MemberFixture {
 
     public static MemberResponses memberResponses() {
         return MemberResponses.from(
-            Lists.newArrayList(createWithInfo(MEMBER_ID, KAKAO_ID, EMAIL, NAME), createWithInfo(MEMBER_ID2, KAKAO_ID2, EMAIL2, NAME2),
+            Lists.newArrayList(createWithInfo(MEMBER_ID, KAKAO_ID, EMAIL, NAME),
+                createWithInfo(MEMBER_ID2, KAKAO_ID2, EMAIL2, NAME2),
                 createWithInfo(MEMBER_ID3, KAKAO_ID3, EMAIL3, NAME3)));
     }
 
@@ -180,19 +180,6 @@ public class MemberFixture {
             .id(id)
             .kakaoId(KAKAO_ID)
             .profile(new ImageUrl(TEST_UPDATED_URL))
-            .email(EMAIL)
-            .name(NAME)
-            .cash(CASH)
-            .role(ROLE)
-            .build();
-    }
-
-    public static Member memberUpdatedBasicProfile(final Long id) {
-        return Member.builder()
-            .id(id)
-            .kakaoId(KAKAO_ID)
-            .profile(new ImageUrl(
-                String.format("%s/%s/%s", UPLOAD_SERVER_URL, PROFILE_UPLOAD_PATH, BASIC_PROFILE_FILE_NAME)))
             .email(EMAIL)
             .name(NAME)
             .cash(CASH)

--- a/src/test/java/com/woowacourse/pelotonbackend/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/domain/MemberRepositoryTest.java
@@ -81,15 +81,4 @@ class MemberRepositoryTest {
 
         assertThat(persistMember).isEqualToIgnoringGivenFields(member, "createdAt", "updatedAt");
     }
-
-    @DisplayName("Profile image가 null인 회원도 저장되는지 확인한다")
-    @Test
-    void profileNullMemberCanSave() {
-        final Member member = createWithoutId(KAKAO_ID, EMAIL, NAME)
-            .toBuilder()
-            .profile(null)
-            .build();
-
-        assertThat(memberRepository.save(member).getId()).isNotNull();
-    }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/domain/MemberRepositoryTest.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.validation.ConstraintViolationException;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestExecutionListeners;
 
 import com.woowacourse.pelotonbackend.DataInitializeExecutionListener;
+import com.woowacourse.pelotonbackend.vo.ImageUrl;
 
 @SpringBootTest
 @TestExecutionListeners(
@@ -37,6 +40,32 @@ class MemberRepositoryTest {
             () -> assertThat(persistMember.getCreatedAt()).isNotNull(),
             () -> assertThat(persistMember.getUpdatedAt()).isNotNull()
         );
+    }
+
+    @DisplayName("Profile image의 url이 null인 회원을 저장하면 예외가 발생한다.")
+    @Test
+    void saveMemberWithNullProfile_ThrowsException() {
+        final Member member = createWithoutId(KAKAO_ID, EMAIL, NAME)
+            .toBuilder()
+            .profile(null)
+            .build();
+
+        assertThatThrownBy(() -> memberRepository.save(member))
+            .isInstanceOf(ConstraintViolationException.class)
+            .hasMessage("profile: 널이어서는 안됩니다");
+    }
+
+    @DisplayName("Profile image의 url이 null인 회원을 저장하면 예외가 발생한다.")
+    @Test
+    void saveMemberWithNullProfileUrl_ThrowsException() {
+        final Member member = createWithoutId(KAKAO_ID, EMAIL, NAME)
+            .toBuilder()
+            .profile(new ImageUrl(null))
+            .build();
+
+        assertThatThrownBy(() -> memberRepository.save(member))
+            .isInstanceOf(ConstraintViolationException.class)
+            .hasMessage("profile.baseImageUrl: 공백일 수 없습니다");
     }
 
     @DisplayName("모든 회원들을 리스트로 반환한다.")


### PR DESCRIPTION
회원 가입 시에 카카오 프사가 없을 경우 기본 이미지를 활용하도록 수정했습니다.
Member의 profileImage 필드는 이제 다시 NotNull입니다.