### PR TITLE
refactor: 백엔드에서 UTC기준 ISO 8601형식을 사용하도록 수정

### DIFF
--- a/src/main/java/com/woowacourse/pelotonbackend/certification/presentation/dto/CertificationCreateRequest.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/certification/presentation/dto/CertificationCreateRequest.java
@@ -7,12 +7,9 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.woowacourse.pelotonbackend.certification.domain.Certification;
 import com.woowacourse.pelotonbackend.certification.domain.CertificationStatus;
 import com.woowacourse.pelotonbackend.vo.ImageUrl;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/woowacourse/pelotonbackend/infra/upload/S3UploadService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/infra/upload/S3UploadService.java
@@ -1,9 +1,6 @@
 package com.woowacourse.pelotonbackend.infra.upload;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 
 import javax.annotation.PostConstruct;
 

--- a/src/main/java/com/woowacourse/pelotonbackend/member/application/LoginService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/application/LoginService.java
@@ -3,9 +3,9 @@ package com.woowacourse.pelotonbackend.member.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.woowacourse.pelotonbackend.infra.login.LoginAPIService;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoTokenResponse;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
-import com.woowacourse.pelotonbackend.infra.login.LoginAPIService;
 import com.woowacourse.pelotonbackend.member.domain.Role;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;

--- a/src/main/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberCashUpdateRequest.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberCashUpdateRequest.java
@@ -4,10 +4,6 @@ import java.beans.ConstructorProperties;
 
 import javax.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.woowacourse.pelotonbackend.support.jsonparser.CashDeserializer;
-import com.woowacourse.pelotonbackend.support.jsonparser.CashSerializer;
 import com.woowacourse.pelotonbackend.vo.Cash;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberProfileResponse.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberProfileResponse.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.member.presentation.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/woowacourse/pelotonbackend/mission/domain/DateTimeDuration.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/mission/domain/DateTimeDuration.java
@@ -3,12 +3,12 @@ package com.woowacourse.pelotonbackend.mission.domain;
 import java.beans.ConstructorProperties;
 import java.time.LocalDateTime;
 
-import javax.validation.constraints.FutureOrPresent;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.woowacourse.pelotonbackend.support.annotation.FutureOrPresentBasedUTC;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
@@ -17,14 +17,14 @@ import lombok.Value;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class DateTimeDuration {
     @NotNull
-    @FutureOrPresent
+    @FutureOrPresentBasedUTC
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     private final LocalDateTime startTime;
     // TODO: 2020/08/09 현재로써 어떻게 사용될 지 정확하지 않으므로 보류
     // TODO: 2020/08/11 해당 객체가 값객체와 Dto 모두로 사용됨. 실제로 프론트 환경에서 객체를 packing하여 보낼 지, unpack해서 보낼 지 정해져있지 않으므로 보류함
 
     @NotNull
-    @FutureOrPresent
+    @FutureOrPresentBasedUTC
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     private final LocalDateTime endTime;
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/mission/domain/DateTimeDuration.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/mission/domain/DateTimeDuration.java
@@ -7,7 +7,11 @@ import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.woowacourse.pelotonbackend.support.annotation.FutureOrPresentBasedUTC;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -16,15 +20,13 @@ import lombok.Value;
 @Value
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class DateTimeDuration {
-    @NotNull
-    @FutureOrPresentBasedUTC
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @NotNull @FutureOrPresentBasedUTC
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonSerialize(using = LocalDateTimeSerializer.class) @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private final LocalDateTime startTime;
-    // TODO: 2020/08/09 현재로써 어떻게 사용될 지 정확하지 않으므로 보류
-    // TODO: 2020/08/11 해당 객체가 값객체와 Dto 모두로 사용됨. 실제로 프론트 환경에서 객체를 packing하여 보낼 지, unpack해서 보낼 지 정해져있지 않으므로 보류함
 
-    @NotNull
-    @FutureOrPresentBasedUTC
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @NotNull @FutureOrPresentBasedUTC
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    @JsonSerialize(using = LocalDateTimeSerializer.class) @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private final LocalDateTime endTime;
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/mission/presentation/dto/MissionCreateRequest.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/mission/presentation/dto/MissionCreateRequest.java
@@ -1,5 +1,7 @@
 package com.woowacourse.pelotonbackend.mission.presentation.dto;
 
+import java.beans.ConstructorProperties;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -15,7 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @ConstructorProperties({"missionDuration", "missionInstruction", "raceId"}))
 @Builder
 @Getter
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)

--- a/src/main/java/com/woowacourse/pelotonbackend/mission/presentation/dto/MissionCreateRequest.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/mission/presentation/dto/MissionCreateRequest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.pelotonbackend.mission.presentation.dto;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
@@ -19,10 +20,10 @@ import lombok.Getter;
 @Getter
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class MissionCreateRequest {
-    @NotNull
+    @NotNull @Valid
     private final DateTimeDuration missionDuration;
 
-    @NotNull
+    @NotNull @Valid
     private final MissionInstruction missionInstruction;
 
     @NotNull

--- a/src/main/java/com/woowacourse/pelotonbackend/mission/presentation/dto/MissionUpdateRequest.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/mission/presentation/dto/MissionUpdateRequest.java
@@ -19,10 +19,10 @@ import lombok.Getter;
 @Getter
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class MissionUpdateRequest {
-    @Valid
+    @NotNull @Valid
     private final DateTimeDuration missionDuration;
 
-    @Valid
+    @NotNull @Valid
     private final MissionInstruction missionInstruction;
 
     @NotNull

--- a/src/main/java/com/woowacourse/pelotonbackend/race/domain/DateDuration.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/race/domain/DateDuration.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.woowacourse.pelotonbackend.support.annotation.FutureOrPresentBasedUTC;
 import com.woowacourse.pelotonbackend.support.jsonparser.LocalDateDeserializer;
 import com.woowacourse.pelotonbackend.support.jsonparser.LocalDateSerializer;
 import lombok.RequiredArgsConstructor;
@@ -18,12 +19,10 @@ import lombok.Value;
 @Value
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class DateDuration {
-    @FutureOrPresent
     @JsonSerialize(using = LocalDateSerializer.class)
     @JsonDeserialize(using = LocalDateDeserializer.class)
     private final LocalDate startDate;
 
-    @FutureOrPresent
     @JsonSerialize(using = LocalDateSerializer.class)
     @JsonDeserialize(using = LocalDateDeserializer.class)
     private final LocalDate endDate;

--- a/src/main/java/com/woowacourse/pelotonbackend/race/domain/DateDuration.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/race/domain/DateDuration.java
@@ -3,13 +3,11 @@ package com.woowacourse.pelotonbackend.race.domain;
 import java.beans.ConstructorProperties;
 import java.time.LocalDate;
 
-import javax.validation.constraints.FutureOrPresent;
-
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.woowacourse.pelotonbackend.support.annotation.FutureOrPresentBasedUTC;
 import com.woowacourse.pelotonbackend.support.jsonparser.LocalDateDeserializer;
 import com.woowacourse.pelotonbackend.support.jsonparser.LocalDateSerializer;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceCreateRequest.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceCreateRequest.java
@@ -34,7 +34,7 @@ public class RaceCreateRequest {
     @NotBlank
     private final String description;
 
-    @Valid
+    @NotNull @Valid
     private final DateDuration raceDuration;
 
     @NotNull
@@ -43,7 +43,7 @@ public class RaceCreateRequest {
     @NotNull
     private final List<DayOfWeek> days;
 
-    @Valid
+    @NotNull @Valid
     private final TimeDuration certificationAvailableDuration;
 
     @Valid

--- a/src/main/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderResponse.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderResponse.java
@@ -5,10 +5,8 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.woowacourse.pelotonbackend.rider.domain.Rider;
 import lombok.AccessLevel;
@@ -27,7 +25,7 @@ public class RiderResponse {
 
     private final Long raceId;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     private final LocalDateTime createdAt;
 

--- a/src/main/java/com/woowacourse/pelotonbackend/support/RandomGeneratorImpl.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/support/RandomGeneratorImpl.java
@@ -3,7 +3,6 @@ package com.woowacourse.pelotonbackend.support;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.Random;
 
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTC.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTC.java
@@ -1,0 +1,23 @@
+package com.woowacourse.pelotonbackend.support.annotation;
+
+import static com.woowacourse.pelotonbackend.support.annotation.FutureOrPresentBasedUTC.*;
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = FutureOrPresentBasedUTCValidator.class)
+@Retention(RUNTIME)
+@Target({FIELD, ANNOTATION_TYPE, TYPE_USE})
+public @interface FutureOrPresentBasedUTC {
+    String message() default "The current or future time should come based on UTC.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTC.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTC.java
@@ -1,10 +1,8 @@
 package com.woowacourse.pelotonbackend.support.annotation;
 
-import static com.woowacourse.pelotonbackend.support.annotation.FutureOrPresentBasedUTC.*;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -13,7 +11,7 @@ import javax.validation.Payload;
 
 @Constraint(validatedBy = FutureOrPresentBasedUTCValidator.class)
 @Retention(RUNTIME)
-@Target({FIELD, ANNOTATION_TYPE, TYPE_USE})
+@Target({FIELD})
 public @interface FutureOrPresentBasedUTC {
     String message() default "The current or future time should come based on UTC.";
 

--- a/src/main/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTCValidator.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTCValidator.java
@@ -1,0 +1,27 @@
+package com.woowacourse.pelotonbackend.support.annotation;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.TimeZone;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class FutureOrPresentBasedUTCValidator implements ConstraintValidator<FutureOrPresentBasedUTC, LocalDateTime> {
+    private static final int MILLIS_TO_HOURS = 3600000;
+    private static final int NETWORK_RELAXATION_TIME = 1;
+
+    @Override
+    public void initialize(final FutureOrPresentBasedUTC constraint) {
+    }
+
+    @Override
+    public boolean isValid(final LocalDateTime field, final ConstraintValidatorContext context) {
+        if (field == null) {
+            return false;
+        }
+        final LocalDateTime systemBasedLocalDateTime = field.plusHours(
+            TimeZone.getDefault().getRawOffset() / MILLIS_TO_HOURS);
+        return systemBasedLocalDateTime.compareTo(LocalDateTime.now().minusMinutes(NETWORK_RELAXATION_TIME)) >= 0;
+    }
+}

--- a/src/main/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTCValidator.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTCValidator.java
@@ -2,13 +2,12 @@ package com.woowacourse.pelotonbackend.support.annotation;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.TimeZone;
+import java.time.ZoneOffset;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 public class FutureOrPresentBasedUTCValidator implements ConstraintValidator<FutureOrPresentBasedUTC, LocalDateTime> {
-    private static final int MILLIS_TO_HOURS = 3600000;
     private static final int NETWORK_RELAXATION_TIME = 1;
 
     @Override
@@ -20,8 +19,7 @@ public class FutureOrPresentBasedUTCValidator implements ConstraintValidator<Fut
         if (field == null) {
             return false;
         }
-        final LocalDateTime systemBasedLocalDateTime = field.plusHours(
-            TimeZone.getDefault().getRawOffset() / MILLIS_TO_HOURS);
-        return systemBasedLocalDateTime.compareTo(LocalDateTime.now().minusMinutes(NETWORK_RELAXATION_TIME)) >= 0;
+        return field.compareTo(LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+            .minusMinutes(NETWORK_RELAXATION_TIME)) >= 0;
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/support/jsonparser/ImageUrlDeserializer.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/support/jsonparser/ImageUrlDeserializer.java
@@ -1,13 +1,11 @@
 package com.woowacourse.pelotonbackend.support.jsonparser;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.woowacourse.pelotonbackend.vo.Cash;
 import com.woowacourse.pelotonbackend.vo.ImageUrl;
 
 public class ImageUrlDeserializer extends JsonDeserializer<ImageUrl> {

--- a/src/main/resources/db/changelog-master.xml
+++ b/src/main/resources/db/changelog-master.xml
@@ -7,4 +7,5 @@
     <include file="./changes/changelog-schema-1.0.1.xml" relativeToChangelogFile="true"/>
     <include file="./changes/changelog-schema-1.0.2.xml" relativeToChangelogFile="true"/>
     <include file="./changes/changelog-schema-1.0.3.xml" relativeToChangelogFile="true"/>
+    <include file="./changes/changelog-schema-1.0.4.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog-master.xml
+++ b/src/main/resources/db/changelog-master.xml
@@ -6,4 +6,5 @@
     <include file="./changes/changelog-schema-1.0.0.xml" relativeToChangelogFile="true"/>
     <include file="./changes/changelog-schema-1.0.1.xml" relativeToChangelogFile="true"/>
     <include file="./changes/changelog-schema-1.0.2.xml" relativeToChangelogFile="true"/>
+    <include file="./changes/changelog-schema-1.0.3.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changes/changelog-schema-1.0.3.xml
+++ b/src/main/resources/db/changes/changelog-schema-1.0.3.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="sika" id="20200814">
+        <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN START_DATE DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN END_DATE DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN START_TIME DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN START_TIME DROP DEFAULT</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changes/changelog-schema-1.0.3.xml
+++ b/src/main/resources/db/changes/changelog-schema-1.0.3.xml
@@ -4,41 +4,75 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <changeSet author="sika" id="20200817">
-        <sql dbms="mariadb">ALTER TABLE member ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE member ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE member MODIFY CREATED_AT DATETIME</sql>
-        <sql dbms="mariadb">ALTER TABLE member MODIFY UPDATED_AT DATETIME</sql>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="CREATED_AT"
+                           tableName="member"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="UPDATED_AT"
+                           tableName="member"/>
 
-        <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN START_DATE DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN END_DATE DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE race MODIFY CREATED_AT DATETIME</sql>
-        <sql dbms="mariadb">ALTER TABLE race MODIFY UPDATED_AT DATETIME</sql>
-        <sql dbms="mariadb">ALTER TABLE race MODIFY START_DATE DATE</sql>
-        <sql dbms="mariadb">ALTER TABLE race MODIFY END_DATE DATE</sql>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="CREATED_AT"
+                           tableName="race"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="UPDATED_AT"
+                           tableName="race"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="START_DATE"
+                           tableName="race"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="END_DATE"
+                           tableName="race"/>
 
-        <sql dbms="mariadb">ALTER TABLE rider ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE rider ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE rider MODIFY CREATED_AT DATETIME</sql>
-        <sql dbms="mariadb">ALTER TABLE rider MODIFY UPDATED_AT DATETIME</sql>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="CREATED_AT"
+                           tableName="rider"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="UPDATED_AT"
+                           tableName="rider"/>
 
-        <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN START_TIME DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN START_TIME DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE mission MODIFY CREATED_AT DATETIME</sql>
-        <sql dbms="mariadb">ALTER TABLE mission MODIFY UPDATED_AT DATETIME</sql>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="CREATED_AT"
+                           tableName="mission"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="UPDATED_AT"
+                           tableName="mission"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="START_TIME"
+                           tableName="mission"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="END_TIME"
+                           tableName="mission"/>
 
-        <sql dbms="mariadb">ALTER TABLE certification ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE certification ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE certification MODIFY CREATED_AT DATETIME</sql>
-        <sql dbms="mariadb">ALTER TABLE certification MODIFY UPDATED_AT DATETIME</sql>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="CREATED_AT"
+                           tableName="certification"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="UPDATED_AT"
+                           tableName="certification"/>
 
-        <sql dbms="mariadb">ALTER TABLE report ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE report ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
-        <sql dbms="mariadb">ALTER TABLE report MODIFY CREATED_AT DATETIME</sql>
-        <sql dbms="mariadb">ALTER TABLE report MODIFY UPDATED_AT DATETIME</sql>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="CREATED_AT"
+                           tableName="report"/>
+        <dropDefaultValue  columnDataType="TIMESTAMP"
+                           schemaName="PUBLIC"
+                           columnName="UPDATED_AT"
+                           tableName="report"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changes/changelog-schema-1.0.3.xml
+++ b/src/main/resources/db/changes/changelog-schema-1.0.3.xml
@@ -3,11 +3,42 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
-    <changeSet author="sika" id="20200814">
+    <changeSet author="sika" id="20200817">
+        <sql dbms="mariadb">ALTER TABLE member ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE member ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE member MODIFY CREATED_AT DATETIME</sql>
+        <sql dbms="mariadb">ALTER TABLE member MODIFY UPDATED_AT DATETIME</sql>
+
+        <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
         <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN START_DATE DROP DEFAULT</sql>
         <sql dbms="mariadb">ALTER TABLE race ALTER COLUMN END_DATE DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE race MODIFY CREATED_AT DATETIME</sql>
+        <sql dbms="mariadb">ALTER TABLE race MODIFY UPDATED_AT DATETIME</sql>
+        <sql dbms="mariadb">ALTER TABLE race MODIFY START_DATE DATE</sql>
+        <sql dbms="mariadb">ALTER TABLE race MODIFY END_DATE DATE</sql>
+
+        <sql dbms="mariadb">ALTER TABLE rider ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE rider ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE rider MODIFY CREATED_AT DATETIME</sql>
+        <sql dbms="mariadb">ALTER TABLE rider MODIFY UPDATED_AT DATETIME</sql>
+
+        <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
         <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN START_TIME DROP DEFAULT</sql>
         <sql dbms="mariadb">ALTER TABLE mission ALTER COLUMN START_TIME DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE mission MODIFY CREATED_AT DATETIME</sql>
+        <sql dbms="mariadb">ALTER TABLE mission MODIFY UPDATED_AT DATETIME</sql>
+
+        <sql dbms="mariadb">ALTER TABLE certification ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE certification ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE certification MODIFY CREATED_AT DATETIME</sql>
+        <sql dbms="mariadb">ALTER TABLE certification MODIFY UPDATED_AT DATETIME</sql>
+
+        <sql dbms="mariadb">ALTER TABLE report ALTER COLUMN CREATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE report ALTER COLUMN UPDATED_AT DROP DEFAULT</sql>
+        <sql dbms="mariadb">ALTER TABLE report MODIFY CREATED_AT DATETIME</sql>
+        <sql dbms="mariadb">ALTER TABLE report MODIFY UPDATED_AT DATETIME</sql>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changes/changelog-schema-1.0.4.xml
+++ b/src/main/resources/db/changes/changelog-schema-1.0.4.xml
@@ -1,0 +1,78 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="sika" id="20200818">
+        <modifyDataType columnName="CREATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="member"/>
+        <modifyDataType columnName="UPDATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="member"/>
+
+        <modifyDataType columnName="CREATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="race"/>
+        <modifyDataType columnName="UPDATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="race"/>
+        <modifyDataType columnName="START_DATE"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="race"/>
+        <modifyDataType columnName="END_DATE"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="race"/>
+
+        <modifyDataType columnName="CREATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="rider"/>
+        <modifyDataType columnName="UPDATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="rider"/>
+
+        <modifyDataType columnName="CREATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="mission"/>
+        <modifyDataType columnName="UPDATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="mission"/>
+        <modifyDataType columnName="START_TIME"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="mission"/>
+        <modifyDataType columnName="END_TIME"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="mission"/>
+
+        <modifyDataType columnName="CREATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="certification"/>
+        <modifyDataType columnName="UPDATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="certification"/>
+
+        <modifyDataType columnName="CREATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="report"/>
+        <modifyDataType columnName="UPDATED_AT"
+                        schemaName="PUBLIC"
+                        newDataType="DATETIME"
+                        tableName="report"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/dto/CertificationDescriptionUpdateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/dto/CertificationDescriptionUpdateRequestTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.pelotonbackend.certification.presentation.dto;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/dto/CertificationResponseTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/dto/CertificationResponseTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.pelotonbackend.certification.presentation.dto;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/dto/CertificationStatusUpdateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/certification/presentation/dto/CertificationStatusUpdateRequestTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.pelotonbackend.certification.presentation.dto;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/infra/login/dto/KakaoTokenResponseTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/infra/login/dto/KakaoTokenResponseTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.infra.login.dto;
 
 import static com.woowacourse.pelotonbackend.member.domain.LoginFixture.*;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/member/application/LoginServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/application/LoginServiceTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.woowacourse.pelotonbackend.infra.login.LoginAPIService;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoTokenResponse;
 import com.woowacourse.pelotonbackend.infra.login.dto.KakaoUserResponse;
-import com.woowacourse.pelotonbackend.infra.login.LoginAPIService;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberCreateRequest;
 import com.woowacourse.pelotonbackend.support.JwtTokenProvider;
 import com.woowacourse.pelotonbackend.support.RandomGenerator;

--- a/src/test/java/com/woowacourse/pelotonbackend/member/presentation/LoginMemberArgumentResolverIntegrationTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/presentation/LoginMemberArgumentResolverIntegrationTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.member.presentation;
 
 import static io.restassured.RestAssured.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberCashUpdateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberCashUpdateRequestTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.member.presentation.dto;
 
 import static com.woowacourse.pelotonbackend.member.domain.MemberFixture.*;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberCreateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberCreateRequestTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.pelotonbackend.member.presentation.dto;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberNameUpdateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberNameUpdateRequestTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.pelotonbackend.member.presentation.dto;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberProfileResponseTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberProfileResponseTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.member.presentation.dto;
 
 import static com.woowacourse.pelotonbackend.member.domain.MemberFixture.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberResponseTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/member/presentation/dto/MemberResponseTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.member.presentation.dto;
 
 import static com.woowacourse.pelotonbackend.member.domain.MemberFixture.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/mission/domain/MissionFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/mission/domain/MissionFixture.java
@@ -1,9 +1,10 @@
 package com.woowacourse.pelotonbackend.mission.domain;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,8 +25,8 @@ public class MissionFixture {
     public static final LocalDateTime END_TIME = LocalDateTime.parse(LocalDateTime.now().plusYears(3L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
     public static final DateTimeDuration MISSION_DURATION = new DateTimeDuration(START_TIME, END_TIME);
     private static final DateTimeDuration MISSION_UTC_DURATION = new DateTimeDuration(
-        LocalDateTime.parse(LocalDateTime.now().minusHours(9L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))),
-        LocalDateTime.parse(LocalDateTime.now().plusHours(9L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))));
+        LocalDateTime.parse(LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))),
+        LocalDateTime.parse(LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).plusHours(9L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))));
     public static final LocalDateTime START_TIME_UPDATED = LocalDateTime.parse(LocalDateTime.now().plusYears(9L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
     public static final LocalDateTime END_TIME_UPDATED = LocalDateTime.parse(LocalDateTime.now().plusYears(10L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
     public static final DateTimeDuration MISSION_DURATION_UPDATED = new DateTimeDuration(START_TIME_UPDATED,

--- a/src/test/java/com/woowacourse/pelotonbackend/mission/domain/MissionFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/mission/domain/MissionFixture.java
@@ -3,6 +3,7 @@ package com.woowacourse.pelotonbackend.mission.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,17 +20,14 @@ import com.woowacourse.pelotonbackend.mission.presentation.dto.MissionUpdateRequ
 
 public class MissionFixture {
     public static final Long TEST_MISSION_ID = 1L;
-    public static final LocalDateTime START_TIME = LocalDateTime.parse(LocalDateTime.of(2021, 1, 1, 9, 0).format(
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
-    public static final LocalDateTime END_TIME = LocalDateTime.parse(LocalDateTime.of(2021, 1, 31, 12, 0).format(
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
+    public static final LocalDateTime START_TIME = LocalDateTime.parse(LocalDateTime.now().plusYears(2L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
+    public static final LocalDateTime END_TIME = LocalDateTime.parse(LocalDateTime.now().plusYears(3L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
     public static final DateTimeDuration MISSION_DURATION = new DateTimeDuration(START_TIME, END_TIME);
-    public static final LocalDateTime START_TIME_UPDATED = LocalDateTime.parse(
-        LocalDateTime.of(2023, 9, 1, 9, 0).format(
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
-    public static final LocalDateTime END_TIME_UPDATED = LocalDateTime.parse(
-        LocalDateTime.of(2023, 9, 30, 12, 0).format(
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
+    private static final DateTimeDuration MISSION_UTC_DURATION = new DateTimeDuration(
+        LocalDateTime.parse(LocalDateTime.now().minusHours(9L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))),
+        LocalDateTime.parse(LocalDateTime.now().plusHours(9L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"))));
+    public static final LocalDateTime START_TIME_UPDATED = LocalDateTime.parse(LocalDateTime.now().plusYears(9L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
+    public static final LocalDateTime END_TIME_UPDATED = LocalDateTime.parse(LocalDateTime.now().plusYears(10L).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
     public static final DateTimeDuration MISSION_DURATION_UPDATED = new DateTimeDuration(START_TIME_UPDATED,
         END_TIME_UPDATED);
     public static final MissionInstruction MISSION_INSTRUCTION = new MissionInstruction("다같이 손을 잡고 사진을 찍는다.");
@@ -116,6 +114,14 @@ public class MissionFixture {
 
     public static MissionCreateRequest badMockCreateRequest() {
         return MissionCreateRequest.builder()
+            .raceId(RACE_ID)
+            .build();
+    }
+
+    public static MissionCreateRequest mockUTCCreateRequest() {
+        return MissionCreateRequest.builder()
+            .missionDuration(MISSION_UTC_DURATION)
+            .missionInstruction(MISSION_INSTRUCTION)
             .raceId(RACE_ID)
             .build();
     }

--- a/src/test/java/com/woowacourse/pelotonbackend/mission/presentation/MissionControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/mission/presentation/MissionControllerTest.java
@@ -9,8 +9,6 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.TimeZone;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -19,11 +17,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -43,12 +38,9 @@ import com.woowacourse.pelotonbackend.member.domain.LoginFixture;
 import com.woowacourse.pelotonbackend.member.presentation.LoginMemberArgumentResolver;
 import com.woowacourse.pelotonbackend.mission.application.MissionService;
 import com.woowacourse.pelotonbackend.mission.domain.MissionFixture;
-import com.woowacourse.pelotonbackend.mission.presentation.dto.MissionCreateRequest;
 import com.woowacourse.pelotonbackend.mission.presentation.dto.MissionResponse;
 import com.woowacourse.pelotonbackend.mission.presentation.dto.MissionUpdateRequest;
 import com.woowacourse.pelotonbackend.support.BearerAuthInterceptor;
-import com.woowacourse.pelotonbackend.support.annotation.FutureOrPresentBasedUTC;
-import com.woowacourse.pelotonbackend.support.annotation.FutureOrPresentBasedUTCValidator;
 
 @ExtendWith(RestDocumentationExtension.class)
 @WebMvcTest(MissionController.class)

--- a/src/test/java/com/woowacourse/pelotonbackend/mission/presentation/dto/MissionCreateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/mission/presentation/dto/MissionCreateRequestTest.java
@@ -1,0 +1,37 @@
+package com.woowacourse.pelotonbackend.mission.presentation.dto;
+
+import static com.woowacourse.pelotonbackend.rider.domain.RiderFixture.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.pelotonbackend.mission.domain.MissionFixture;
+
+class MissionCreateRequestTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("요청이 정상적으로 dto로 변환되는지 확인한다.")
+    @Test
+    void missionCreateRequestTest() throws JsonProcessingException {
+        final String requestBody = "{\n"
+            + "    \"mission_duration\": {\n"
+            + "        \"start_time\": " + "\"" + MissionFixture.START_TIME + "Z\",\n"
+            + "        \"end_time\": " + "\"" + MissionFixture.END_TIME + "Z\"\n"
+            + "    },\n"
+            + "    \"mission_instruction\": " + "\"" + MissionFixture.MISSION_INSTRUCTION.getMissionInstruction() + "\"\n,"
+            + "    \"race_id\": 7"
+            + "}";
+
+        final MissionCreateRequest missionCreateRequest = objectMapper.readValue(requestBody,
+            MissionCreateRequest.class);
+
+        assertThat(missionCreateRequest).isEqualToComparingFieldByField(MissionFixture.mockCreateRequest());
+    }
+}

--- a/src/test/java/com/woowacourse/pelotonbackend/race/domain/RaceFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/race/domain/RaceFixture.java
@@ -3,10 +3,8 @@ package com.woowacourse.pelotonbackend.race.domain;
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.Arrays;
 
-import com.woowacourse.pelotonbackend.certification.domain.TimeDuration;
 import com.woowacourse.pelotonbackend.mission.domain.MissionFixture;
 import com.woowacourse.pelotonbackend.race.presentation.dto.RaceCreateRequest;
 import com.woowacourse.pelotonbackend.race.presentation.dto.RaceResponse;

--- a/src/test/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceCreateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceCreateRequestTest.java
@@ -8,14 +8,12 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Arrays;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.pelotonbackend.certification.domain.TimeDuration;
 import com.woowacourse.pelotonbackend.race.domain.DateDuration;

--- a/src/test/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceDtoTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceDtoTest.java
@@ -3,20 +3,12 @@ package com.woowacourse.pelotonbackend.race.presentation.dto;
 import static com.woowacourse.pelotonbackend.race.domain.RaceFixture.*;
 import static org.assertj.core.api.Assertions.*;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.pelotonbackend.race.domain.DateDuration;
-import com.woowacourse.pelotonbackend.race.domain.RaceCategory;
 import com.woowacourse.pelotonbackend.race.domain.RaceFixture;
-import com.woowacourse.pelotonbackend.vo.Cash;
 
 class RaceDtoTest {
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceRetrieveResponseTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceRetrieveResponseTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.race.presentation.dto;
 
 import static com.woowacourse.pelotonbackend.race.domain.RaceFixture.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceUpdateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/race/presentation/dto/RaceUpdateRequestTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.pelotonbackend.race.domain.Race;
 import com.woowacourse.pelotonbackend.race.domain.RaceFixture;
-import com.woowacourse.pelotonbackend.race.presentation.dto.RaceUpdateRequest;
 
 class RaceUpdateRequestTest {
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/com/woowacourse/pelotonbackend/report/presentation/dto/ReportCreateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/report/presentation/dto/ReportCreateRequestTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.pelotonbackend.report.presentation.dto;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/domain/RiderFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/domain/RiderFixture.java
@@ -1,6 +1,8 @@
 package com.woowacourse.pelotonbackend.rider.domain;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,7 +21,9 @@ public class RiderFixture {
     public static final Long TEST_MEMBER_ID = 1L;
     public static final Long TEST_CHANGED_RACE_ID = 8L;
     public static final Long TEST_CHANGED_MEMBER_ID = 11L;
-    public static final LocalDateTime TEST_CREATED_DATE_TIME = LocalDateTime.parse(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
+    public static final LocalDateTime TEST_CREATED_DATE_TIME =
+        LocalDateTime.parse(LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")));
     public static final int RIDER_NUMBER = 3;
 
     public static RiderCreateRequest createMockRequest() {

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderCreateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderCreateRequestTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.pelotonbackend.rider.presentation.dto;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderResponseTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderResponseTest.java
@@ -3,6 +3,10 @@ package com.woowacourse.pelotonbackend.rider.presentation.dto;
 import static com.woowacourse.pelotonbackend.rider.domain.RiderFixture.*;
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +24,7 @@ class RiderResponseTest {
             + "\"id\":1,"
             + "\"member_id\":1,"
             + "\"race_id\":7,"
-            + "\"created_at\":\"" + TEST_CREATED_DATE_TIME + "\""
+            + "\"created_at\":\"" + TEST_CREATED_DATE_TIME + "Z\""
             + "}";
 
         assertThat(objectMapper.writeValueAsString(RiderFixture.createRiderResponse(1L))).isEqualTo(responseBody);

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderResponsesTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderResponsesTest.java
@@ -2,14 +2,12 @@ package com.woowacourse.pelotonbackend.rider.presentation.dto;
 
 import static com.woowacourse.pelotonbackend.rider.domain.RiderFixture.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.woowacourse.pelotonbackend.rider.domain.RiderFixture;
 
 class RiderResponsesTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -23,19 +21,19 @@ class RiderResponsesTest {
             + "\"id\":1,"
             + "\"member_id\":1,"
             + "\"race_id\":7,"
-            + "\"created_at\":\"" + TEST_CREATED_DATE_TIME + "\""
+            + "\"created_at\":\"" + TEST_CREATED_DATE_TIME + "Z\""
             + "},"
             + "{"
             + "\"id\":2,"
             + "\"member_id\":1,"
             + "\"race_id\":7,"
-            + "\"created_at\":\"" + TEST_CREATED_DATE_TIME + "\""
+            + "\"created_at\":\"" + TEST_CREATED_DATE_TIME + "Z\""
             + "},"
             + "{"
             + "\"id\":3,"
             + "\"member_id\":1,"
             + "\"race_id\":7,"
-            + "\"created_at\":\"" + TEST_CREATED_DATE_TIME + "\""
+            + "\"created_at\":\"" + TEST_CREATED_DATE_TIME + "Z\""
             + "}"
             + "]"
             + "}";

--- a/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderUpdateRequestTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/rider/presentation/dto/RiderUpdateRequestTest.java
@@ -2,7 +2,6 @@ package com.woowacourse.pelotonbackend.rider.presentation.dto;
 
 import static com.woowacourse.pelotonbackend.rider.domain.RiderFixture.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/woowacourse/pelotonbackend/support/CustomDateParserTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/support/CustomDateParserTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/test/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTCValidatorTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTCValidatorTest.java
@@ -1,0 +1,58 @@
+package com.woowacourse.pelotonbackend.support.annotation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDateTime;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class FutureOrPresentBasedUTCValidatorTest {
+    private static final int MILLIS_TO_HOURS = 3600000;
+    private final FutureOrPresentBasedUTCValidator validator = new FutureOrPresentBasedUTCValidator();
+
+    @DisplayName("LocalDateTime이 futureOrPresent면 true를 반환하고 아니라면 false를 반환한다.")
+    @ParameterizedTest
+    @MethodSource("provideFutureOrPresentLocalDateTime")
+    void isValidTest(final LocalDateTime input, final boolean expected) {
+        assertThat(validator.isValid(input, null)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideFutureOrPresentLocalDateTime() {
+        return Stream.of(
+            Arguments.of(LocalDateTime.now(), true),
+            Arguments.of(LocalDateTime.now().plusYears(1L), true),
+            Arguments.of(LocalDateTime.now().plusMonths(1L), true),
+            Arguments.of(LocalDateTime.now().plusWeeks(1L), true),
+            Arguments.of(LocalDateTime.now().plusDays(1L), true),
+            Arguments.of(LocalDateTime.now().plusHours(1L), true),
+            Arguments.of(LocalDateTime.now().plusMinutes(1L), true),
+            Arguments.of(LocalDateTime.now().plusSeconds(1L), true),
+            Arguments.of(LocalDateTime.now().plusNanos(1L), true),
+            Arguments.of(LocalDateTime.now().minusYears(1L), false),
+            Arguments.of(LocalDateTime.now().minusMonths(1L), false),
+            Arguments.of(LocalDateTime.now().minusWeeks(1L), false),
+            Arguments.of(LocalDateTime.now().minusDays(1L), false)
+        );
+    }
+
+    @DisplayName("LocalDateTime이 UTC기준이여도 true를 반환한다.")
+    @Test
+    void isValidTest2() {
+        final int timezoneOffset = TimeZone.getDefault().getRawOffset() / MILLIS_TO_HOURS;
+
+        assertThat(validator.isValid(LocalDateTime.now().minusHours(timezoneOffset), null)).isTrue();
+    }
+
+    @DisplayName("field가 null이면 false를 반환한다.")
+    @Test
+    void isValidTest3() {
+        assertThat(validator.isValid(null, null)).isFalse();
+    }
+}

--- a/src/test/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTCValidatorTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/support/annotation/FutureOrPresentBasedUTCValidatorTest.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import java.util.TimeZone;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
- refactor: 프론트에서 ISO형식 `yyyy-MM-dd'T'hh:mm:ss.SSS'Z'`  으로 보낼 때 dto에서 parsing을 제대로 하도록 수정
- refactor: `@FutrueOrPresent`가 sytstem.defaultTimezone을 사용하기 때문에 커스텀 어노테이션을 통해 제대로 동작하도록 수정
- chore: liquibase changelog에 column 속성 및 default값 수정

closed #228 