### PR TITLE
refactor: 로그아웃, 삭제, 프로필이미지 업로드 수정했습니다.

### DIFF
--- a/peloton-frontend/component/LoginNavigationRoot.js
+++ b/peloton-frontend/component/LoginNavigationRoot.js
@@ -3,7 +3,6 @@ import { createStackNavigator } from "@react-navigation/stack";
 import ChangeProfile from "./login/ChangeProfile";
 import Login from "./login/Login";
 import ApplicationNavigationRoot from "./ApplicationNavigationRoot";
-import GoBackButton from "./home/race/GoBackButton";
 
 const LoginStack = createStackNavigator();
 

--- a/peloton-frontend/component/LoginNavigationRoot.js
+++ b/peloton-frontend/component/LoginNavigationRoot.js
@@ -18,7 +18,7 @@ const LoginNavigationRoot = () => {
       <LoginStack.Screen
         name="ChangeProfile"
         component={ChangeProfile}
-        options={{ headerShown: false}}
+        options={{ headerShown: false }}
       />
       <LoginStack.Screen
         name="ApplicationNavigationRoot"

--- a/peloton-frontend/component/LoginNavigationRoot.js
+++ b/peloton-frontend/component/LoginNavigationRoot.js
@@ -3,6 +3,7 @@ import { createStackNavigator } from "@react-navigation/stack";
 import ChangeProfile from "./login/ChangeProfile";
 import Login from "./login/Login";
 import ApplicationNavigationRoot from "./ApplicationNavigationRoot";
+import GoBackButton from "./home/race/GoBackButton";
 
 const LoginStack = createStackNavigator();
 
@@ -17,7 +18,7 @@ const LoginNavigationRoot = () => {
       <LoginStack.Screen
         name="ChangeProfile"
         component={ChangeProfile}
-        options={{ headerShown: false }}
+        options={{ headerShown: false}}
       />
       <LoginStack.Screen
         name="ApplicationNavigationRoot"

--- a/peloton-frontend/component/home/race/RaceShareButton.js
+++ b/peloton-frontend/component/home/race/RaceShareButton.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Share, StyleSheet, TouchableOpacity } from "react-native";
 import { EvilIcons } from "@expo/vector-icons";
 import { useRecoilValue } from "recoil";
-
 import { COLOR } from "../../../utils/constants";
 import { raceInfoState } from "../../../state/race/RaceState";
 import { raceShareLink } from "./RaceDeepLinkPage";

--- a/peloton-frontend/component/login/Login.js
+++ b/peloton-frontend/component/login/Login.js
@@ -1,5 +1,11 @@
 import React, { useState } from "react";
-import { Modal, SafeAreaView, StyleSheet, TouchableOpacity, View } from "react-native";
+import {
+  Modal,
+  SafeAreaView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import KakaoLoginWebView from "./KakaoLoginWebView";
 import LoginTitle from "./LoginTitle";
 import * as AppleAuthentication from "expo-apple-authentication";
@@ -11,7 +17,10 @@ import { useNavigation } from "@react-navigation/core";
 import LoadingIndicator from "../../utils/LoadingIndicator";
 import { loadingState } from "../../state/loading/LoadingState";
 import { navigateWithoutHistory } from "../../utils/util";
-import { memberInfoState, memberTokenState } from "../../state/member/MemberState";
+import {
+  memberInfoState,
+  memberTokenState,
+} from "../../state/member/MemberState";
 import { MemberApi } from "../../utils/api/MemberApi";
 
 const AnimatedAppleButton = animated(

--- a/peloton-frontend/component/login/ProfileImageSelect.js
+++ b/peloton-frontend/component/login/ProfileImageSelect.js
@@ -1,8 +1,6 @@
 import React from "react";
-import { Image, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import ProfileImageEditButton from "../profile/ProfileImageEditButton";
-import { useRecoilValue } from "recoil";
-import { memberInfoState } from "../../state/member/MemberState";
 import CameraIcon from "../profile/profileedit/CameraIcon";
 import ProfileImage from "../profile/ProfileImage";
 

--- a/peloton-frontend/component/login/ProfileImageSelect.js
+++ b/peloton-frontend/component/login/ProfileImageSelect.js
@@ -9,7 +9,7 @@ import ProfileImage from "../profile/ProfileImage";
 const ProfileImageSelect = () => {
   return (
     <View style={styles.container}>
-      <ProfileImageEditButton>
+      <ProfileImageEditButton directUpdate={false}>
         <ProfileImage />
         <CameraIcon />
       </ProfileImageEditButton>

--- a/peloton-frontend/component/login/ProfileImageSelect.js
+++ b/peloton-frontend/component/login/ProfileImageSelect.js
@@ -4,22 +4,13 @@ import ProfileImageEditButton from "../profile/ProfileImageEditButton";
 import { useRecoilValue } from "recoil";
 import { memberInfoState } from "../../state/member/MemberState";
 import CameraIcon from "../profile/profileedit/CameraIcon";
+import ProfileImage from "../profile/ProfileImage";
 
 const ProfileImageSelect = () => {
-  const memberInfo = useRecoilValue(memberInfoState);
-
   return (
     <View style={styles.container}>
       <ProfileImageEditButton>
-        <Image
-          style={styles.profileImage}
-          source={
-            memberInfo.profile
-              ? { uri: memberInfo.profile }
-              : require("../../assets/default-profile.jpg")
-          }
-          defaultSource={require("../../assets/default-profile.jpg")}
-        />
+        <ProfileImage />
         <CameraIcon />
       </ProfileImageEditButton>
     </View>
@@ -30,11 +21,6 @@ const styles = StyleSheet.create({
   container: {
     paddingBottom: 130,
     minHeight: 120,
-  },
-  profileImage: {
-    height: 120,
-    width: 120,
-    borderRadius: 60,
   },
 });
 

--- a/peloton-frontend/component/profile/ProfileImage.js
+++ b/peloton-frontend/component/profile/ProfileImage.js
@@ -6,32 +6,24 @@ import { memberInfoState } from "../../state/member/MemberState";
 const ProfileImage = () => {
   const memberInfo = useRecoilValue(memberInfoState);
   return (
-    <View style={styles.container}>
-      <Image
-        style={styles.profileImage}
-        source={{ uri: memberInfo.profile }}
-        defaultSource={require("../../assets/default-profile.jpg")}
-      />
-    </View>
+    <Image
+      style={styles.profileImage}
+      source={
+        memberInfo
+          ? { uri: memberInfo.profile }
+          : require("../../assets/default-profile.jpg")
+      }
+      defaultSource={require("../../assets/default-profile.jpg")}
+    />
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   profileImage: {
     resizeMode: "cover",
-    width: 100,
-    height: 100,
-    borderRadius: 100 / 2,
-  },
-  profileEditButton: {
-    width: 30,
-    height: 30,
-    position: "absolute",
-    left: 30,
-    bottom: 30,
+    width: 125,
+    height: 125,
+    borderRadius: 125 / 2,
   },
 });
 

--- a/peloton-frontend/component/profile/ProfileImage.js
+++ b/peloton-frontend/component/profile/ProfileImage.js
@@ -23,7 +23,7 @@ const styles = StyleSheet.create({
     resizeMode: "cover",
     width: 125,
     height: 125,
-    borderRadius: 125 / 2,
+    borderRadius: 63,
   },
 });
 

--- a/peloton-frontend/component/profile/ProfileImageEditButton.js
+++ b/peloton-frontend/component/profile/ProfileImageEditButton.js
@@ -11,28 +11,10 @@ import {
 import { loadingState } from "../../state/loading/LoadingState";
 import { getCameraRollPermission } from "../../utils/Permission";
 
-const ProfileImageEditButton = ({ children }) => {
+const ProfileImageEditButton = ({ children, directUpdate }) => {
+  const token = useRecoilValue(memberTokenState);
   const [memberInfo, setMemberInfo] = useRecoilState(memberInfoState);
   const setIsLoading = useSetRecoilState(loadingState);
-  const token = useRecoilValue(memberTokenState);
-
-  const requestChangeImage = async (selectedImage) => {
-    const formData = new FormData();
-    formData.append("profile_image", {
-      uri: selectedImage,
-      type: "image/jpeg",
-      name: selectedImage.substring(9),
-    });
-    try {
-      const profile = await MemberApi.postProfile(token, formData);
-      setMemberInfo({
-        ...memberInfo,
-        profile,
-      });
-    } catch (error) {
-      alert("에러가 발생했습니다.");
-    }
-  };
 
   const pickAndChangeProfileImage = async () => {
     setIsLoading(true);
@@ -40,20 +22,32 @@ const ProfileImageEditButton = ({ children }) => {
     if (hasCameraRollPermission === false) {
       setIsLoading(false);
       return;
+    } else {
+      const pickerResult = await ImagePicker.launchImageLibraryAsync({
+        allowsEditing: true,
+        aspect: [4, 3],
+        quality: 0.1,
+      });
+      if (pickerResult.cancelled === true) {
+        console.log("cameraroll picker cancelled");
+        setIsLoading(false);
+        return;
+      }
+      const profile = pickerResult.uri;
+      setMemberInfo({
+        ...memberInfo,
+        profile,
+      });
+      if (directUpdate) {
+        const formData = new FormData();
+        formData.append("profile_image", {
+          uri: profile,
+          type: "image/jpeg",
+          name: profile.substring(9),
+        });
+        await MemberApi.postProfile(token, formData);
+      }
     }
-    const pickerResult = await ImagePicker.launchImageLibraryAsync({
-      allowsEditing: true,
-      aspect: [1, 1],
-      base64: true,
-      quality: 0.1,
-    });
-
-    if (pickerResult.cancelled === true) {
-      setIsLoading(false);
-      return;
-    }
-    const selectedImage = pickerResult.uri;
-    await requestChangeImage(selectedImage);
     setIsLoading(false);
   };
 

--- a/peloton-frontend/component/profile/ProfileImageEditButton.js
+++ b/peloton-frontend/component/profile/ProfileImageEditButton.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Alert, Linking, TouchableOpacity } from "react-native";
+import { StyleSheet, Alert, Linking, TouchableOpacity } from "react-native";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import * as ImagePicker from "expo-image-picker";
 
@@ -58,10 +58,20 @@ const ProfileImageEditButton = ({ children }) => {
   };
 
   return (
-    <TouchableOpacity onPress={pickAndChangeProfileImage}>
+    <TouchableOpacity
+      style={styles.profileImageEditButton}
+      onPress={pickAndChangeProfileImage}
+    >
       {children}
     </TouchableOpacity>
   );
 };
+
+const styles = StyleSheet.create({
+  profileImageEditButton: {
+    width: 125,
+    height: 125,
+  },
+});
 
 export default ProfileImageEditButton;

--- a/peloton-frontend/component/profile/profiledetail/ProfileDetail.js
+++ b/peloton-frontend/component/profile/profiledetail/ProfileDetail.js
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   memberContainer: {
-    flex: 9,
+    flex: 1,
     backgroundColor: COLOR.RED,
     alignItems: "center",
   },
@@ -39,7 +39,7 @@ const styles = StyleSheet.create({
     width: "120%",
   },
   raceContainer: {
-    flex: 11,
+    flex: 1,
   },
 });
 

--- a/peloton-frontend/component/profile/profileedit/ProfileImageEdit.js
+++ b/peloton-frontend/component/profile/profileedit/ProfileImageEdit.js
@@ -7,7 +7,7 @@ import CameraIcon from "./CameraIcon";
 const ProfileImageEdit = () => {
   return (
     <View style={styles.imageContainer}>
-      <ProfileImageEditButton>
+      <ProfileImageEditButton directUpdate={true}>
         <ProfileImage />
         <CameraIcon />
       </ProfileImageEditButton>

--- a/peloton-frontend/component/profile/profileedit/SignOutButtonContainer.js
+++ b/peloton-frontend/component/profile/profileedit/SignOutButtonContainer.js
@@ -1,21 +1,40 @@
 import React from "react";
 import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import AsyncStorage from "@react-native-community/async-storage";
-import { useResetRecoilState } from "recoil";
 import { useNavigation } from "@react-navigation/core";
-
 import { navigateWithoutHistory } from "../../../utils/util";
 import { COLOR, TOKEN_STORAGE } from "../../../utils/constants";
-import { memberTokenState } from "../../../state/member/MemberState";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { loadingState } from "../../../state/loading/LoadingState";
+import {
+  memberInfoState,
+  memberTokenState,
+} from "../../../state/member/MemberState";
+import { raceInfoState } from "../../../state/race/RaceState";
+import { raceResponseState } from "../../../state/race/ResponseState";
+import { ridersInfoState } from "../../../state/rider/RiderState";
 
 const SignOutButtonContainer = () => {
   const navigation = useNavigation();
-  const resetTokenState = useResetRecoilState(memberTokenState);
+  const setIsLoading = useSetRecoilState(loadingState);
+  const resetMemberTokenState = useResetRecoilState(memberTokenState);
+  const resetMemberInfoState = useResetRecoilState(memberInfoState);
+  const resetRaceCreateInfoState = useResetRecoilState(memberTokenState);
+  const resetRaceInfoState = useResetRecoilState(raceInfoState);
+  const resetRaceResponseState = useResetRecoilState(raceResponseState);
+  const resetRidersInfoState = useResetRecoilState(ridersInfoState);
 
   const onSignOut = async () => {
+    setIsLoading(true);
     await AsyncStorage.removeItem(TOKEN_STORAGE);
-    resetTokenState();
     navigateWithoutHistory(navigation, "Login");
+    setIsLoading(false);
+    resetMemberTokenState();
+    resetMemberInfoState();
+    resetRaceCreateInfoState();
+    resetRaceInfoState();
+    resetRaceResponseState();
+    resetRidersInfoState();
   };
 
   return (

--- a/peloton-frontend/component/profile/profileedit/UnregisterButtonContainer.js
+++ b/peloton-frontend/component/profile/profileedit/UnregisterButtonContainer.js
@@ -1,25 +1,53 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import Axios from "axios";
 import { useRecoilValue } from "recoil";
-import { COLOR, SERVER_BASE_URL } from "../../../utils/constants";
-import { memberTokenState } from "../../../state/member/MemberState";
+import {
+  COLOR,
+  SERVER_BASE_URL,
+  TOKEN_STORAGE,
+} from "../../../utils/constants";
+import {
+  memberInfoState,
+  memberTokenState,
+} from "../../../state/member/MemberState";
+import { MemberApi } from "../../../utils/api/MemberApi";
+import { navigateWithoutHistory } from "../../../utils/util";
+import AsyncStorage from "@react-native-community/async-storage";
+import { useResetRecoilState, useSetRecoilState } from "recoil";
+import { loadingState } from "../../../state/loading/LoadingState";
+import { raceInfoState } from "../../../state/race/RaceState";
+import { raceResponseState } from "../../../state/race/ResponseState";
+import { ridersInfoState } from "../../../state/rider/RiderState";
 
 const UnregisterButtonContainer = () => {
   const navigation = useNavigation();
   const token = useRecoilValue(memberTokenState);
+  const setIsLoading = useSetRecoilState(loadingState);
+  const resetMemberTokenState = useResetRecoilState(memberTokenState);
+  const resetMemberInfoState = useResetRecoilState(memberInfoState);
+  const resetRaceCreateInfoState = useResetRecoilState(memberTokenState);
+  const resetRaceInfoState = useResetRecoilState(raceInfoState);
+  const resetRaceResponseState = useResetRecoilState(raceResponseState);
+  const resetRidersInfoState = useResetRecoilState(ridersInfoState);
 
-  const requestUnregister = () => {
-    Axios.delete(`${SERVER_BASE_URL}/api/members`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    navigation.navigate("Login");
+  const requestUnregister = async () => {
+    setIsLoading(true);
+    await MemberApi.delete(token);
+    await AsyncStorage.removeItem(TOKEN_STORAGE);
+    navigateWithoutHistory(navigation, "Login");
+    setIsLoading(false);
+    resetMemberTokenState();
+    resetMemberInfoState();
+    resetRaceCreateInfoState();
+    resetRaceInfoState();
+    resetRaceResponseState();
+    resetRidersInfoState();
   };
-  const createTwoButtonAlert = () =>
-    Alert.alert(
+
+  const createTwoButtonAlert = async () =>
+    await Alert.alert(
       "Unregister",
       "정말로 탈퇴하시겠습니까?",
       [
@@ -31,7 +59,7 @@ const UnregisterButtonContainer = () => {
         },
         { text: "Yes", onPress: requestUnregister },
       ],
-      { cancelable: false }
+      { cancelable: false },
     );
 
   return (

--- a/peloton-frontend/state/member/MemberState.js
+++ b/peloton-frontend/state/member/MemberState.js
@@ -2,18 +2,19 @@ import { atom } from "recoil";
 
 export const memberTokenState = atom({
   key: "memberTokenState",
-  default: null,
+  default: "",
 });
 
 export const memberInfoState = atom({
   key: "memberInfoState",
   default: {
-    id: null,
-    kakao_id: null,
-    profile: null,
-    name: null,
-    email: null,
-    cash: null,
-    role: null,
+    id: "",
+    kakao_id: "",
+    profile:
+      "https://14f-guys-image.s3.ap-northeast-2.amazonaws.com/basic.profile.image.png",
+    name: "",
+    email: "",
+    cash: "",
+    role: "",
   },
 });

--- a/peloton-frontend/utils/api/MemberApi.js
+++ b/peloton-frontend/utils/api/MemberApi.js
@@ -64,4 +64,18 @@ export const MemberApi = {
       console.log(error);
     }
   },
+  delete: async (token) => {
+    try {
+      await Axios({
+        method: "DELETE",
+        baseURL: SERVER_BASE_URL,
+        url: "/api/members",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  },
 };


### PR DESCRIPTION
수정 내역은 다음과 같습니다.

- Logout & Sign out 시 모든 상태를 날리도록 수정했습니다. 
- 가입 후 카카오톡 프로필 사진을 정상적으로 불러오도록 수정했습니다.
- 프로필 사진에 수정 버튼 위치를 적절하게 수정했습니다.
- 프로필 사진 수정 시 실제 요청이 전송되는 시점을 다음 버튼을 누르는 순간으로 변경했습니다. 
