### PR TITLE
feat: 레이스 상세정보 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/api-guide.adoc
+++ b/src/docs/asciidoc/api-guide.adoc
@@ -551,3 +551,10 @@ operation::queries/get-certifications-race-not-exist[snippets='http-request,http
 [[resource-query-upcoming-missions]]
 ==== Success
 operation::queries/get-upcoming-missions[snippets='http-request,http-response,request-headers,response-fields']
+
+[[resources-queries-race-detail]]
+=== Get Race Detail
+
+[[resource-query-race-detail]]
+==== Success
+operation::queries/get-race-detail[snippets='http-request,http-response,request-headers,response-fields']

--- a/src/main/java/com/woowacourse/pelotonbackend/query/application/QueryService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/query/application/QueryService.java
@@ -111,7 +111,8 @@ public class QueryService {
     }
 
     public RaceDetailResponse findRaceDetail(final Long raceId) {
-        final Race race = raceRepository.findById(raceId).orElseThrow(() -> new RaceNotFoundException(raceId));
+        final Race race = raceRepository.findById(raceId)
+            .orElseThrow(() -> new RaceNotFoundException(raceId));
         final List<Mission> missions = missionRepository.findByRaceId(raceId);
 
         final List<DayOfWeek> days = extractDaysOfWeekFrom(missions);

--- a/src/main/java/com/woowacourse/pelotonbackend/query/application/QueryService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/query/application/QueryService.java
@@ -1,5 +1,6 @@
 package com.woowacourse.pelotonbackend.query.application;
 
+import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -113,6 +114,16 @@ public class QueryService {
         final Race race = raceRepository.findById(raceId).orElseThrow(() -> new RaceNotFoundException(raceId));
         final List<Mission> missions = missionRepository.findByRaceId(raceId);
 
-        return RaceDetailResponse.of(race, missions);
+        final List<DayOfWeek> days = extractDaysOfWeekFrom(missions);
+
+        return RaceDetailResponse.of(race, missions.get(0).getMissionDuration(), days);
+    }
+
+    private List<DayOfWeek> extractDaysOfWeekFrom(final List<Mission> missions) {
+        return missions.stream()
+            .map(mission -> mission.getMissionDuration().getStartTime())
+            .map(LocalDateTime::getDayOfWeek)
+            .distinct()
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/query/application/QueryService.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/query/application/QueryService.java
@@ -16,10 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.pelotonbackend.certification.domain.Certification;
 import com.woowacourse.pelotonbackend.certification.domain.CertificationRepository;
+import com.woowacourse.pelotonbackend.common.exception.RaceNotFoundException;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
 import com.woowacourse.pelotonbackend.mission.domain.Mission;
 import com.woowacourse.pelotonbackend.mission.domain.MissionRepository;
 import com.woowacourse.pelotonbackend.query.presentation.dto.RaceCertificationsResponse;
+import com.woowacourse.pelotonbackend.query.presentation.dto.RaceDetailResponse;
 import com.woowacourse.pelotonbackend.query.presentation.dto.UpcomingMissionResponse;
 import com.woowacourse.pelotonbackend.query.presentation.dto.UpcomingMissionResponses;
 import com.woowacourse.pelotonbackend.race.domain.Race;
@@ -105,5 +107,12 @@ public class QueryService {
 
         return certificationRepository.findByMissionIds(missionIds, PageRequest.of(0, Integer.MAX_VALUE))
             .getContent();
+    }
+
+    public RaceDetailResponse findRaceDetail(final Long raceId) {
+        final Race race = raceRepository.findById(raceId).orElseThrow(() -> new RaceNotFoundException(raceId));
+        final List<Mission> missions = missionRepository.findByRaceId(raceId);
+
+        return RaceDetailResponse.of(race, missions);
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/query/presentation/QueryController.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/query/presentation/QueryController.java
@@ -8,8 +8,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
-import com.woowacourse.pelotonbackend.query.presentation.dto.RaceCertificationsResponse;
 import com.woowacourse.pelotonbackend.query.application.QueryService;
+import com.woowacourse.pelotonbackend.query.presentation.dto.RaceCertificationsResponse;
+import com.woowacourse.pelotonbackend.query.presentation.dto.RaceDetailResponse;
 import com.woowacourse.pelotonbackend.query.presentation.dto.UpcomingMissionResponses;
 import com.woowacourse.pelotonbackend.race.presentation.dto.RaceResponses;
 import com.woowacourse.pelotonbackend.support.annotation.LoginMember;
@@ -38,5 +39,12 @@ public class QueryController {
         @LoginMember final MemberResponse loginMember) {
 
         return ResponseEntity.ok(queryService.retrieveUpcomingMissionsBy(loginMember));
+    }
+
+    @GetMapping("/races/{raceId}/detail")
+    public ResponseEntity<RaceDetailResponse> findRaceDetail(
+        @PathVariable final Long raceId) {
+
+        return ResponseEntity.ok(queryService.findRaceDetail(raceId));
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/query/presentation/dto/RaceDetailResponse.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/query/presentation/dto/RaceDetailResponse.java
@@ -1,0 +1,64 @@
+package com.woowacourse.pelotonbackend.query.presentation.dto;
+
+import java.beans.ConstructorProperties;
+import java.time.DayOfWeek;
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.woowacourse.pelotonbackend.mission.domain.DateTimeDuration;
+import com.woowacourse.pelotonbackend.mission.domain.Mission;
+import com.woowacourse.pelotonbackend.race.domain.DateDuration;
+import com.woowacourse.pelotonbackend.race.domain.Race;
+import com.woowacourse.pelotonbackend.race.domain.RaceCategory;
+import com.woowacourse.pelotonbackend.vo.Cash;
+import com.woowacourse.pelotonbackend.vo.ImageUrl;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor(
+    access = AccessLevel.PRIVATE,
+    onConstructor_ = @ConstructorProperties(
+        {"id", "title", "description", "thumbnail", "certificationExample", "category", "entranceFee", "days", "raceDuration", "missionDuration"}))
+@Builder
+@Getter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class RaceDetailResponse {
+    private final Long id;
+
+    private final String title;
+
+    private final String description;
+
+    private final ImageUrl thumbnail;
+
+    private final ImageUrl certificationExample;
+
+    private final RaceCategory category;
+
+    private final Cash entranceFee;
+
+    private final List<DayOfWeek> days;
+
+    private final DateDuration raceDuration;
+
+    private final DateTimeDuration missionDuration;
+
+    public static RaceDetailResponse of(final Race race, final List<Mission> missions) {
+        return builder()
+            .id(race.getId())
+            .title(race.getTitle())
+            .description(race.getDescription())
+            .thumbnail(race.getThumbnail())
+            .certificationExample(race.getCertificationExample())
+            .category(race.getCategory())
+            .entranceFee(race.getEntranceFee())
+            .days(Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY))
+            .raceDuration(race.getRaceDuration())
+            .missionDuration(missions.get(0).getMissionDuration())
+            .build();
+    }
+}

--- a/src/main/java/com/woowacourse/pelotonbackend/query/presentation/dto/RaceDetailResponse.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/query/presentation/dto/RaceDetailResponse.java
@@ -2,13 +2,11 @@ package com.woowacourse.pelotonbackend.query.presentation.dto;
 
 import java.beans.ConstructorProperties;
 import java.time.DayOfWeek;
-import java.util.Arrays;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.woowacourse.pelotonbackend.mission.domain.DateTimeDuration;
-import com.woowacourse.pelotonbackend.mission.domain.Mission;
 import com.woowacourse.pelotonbackend.race.domain.DateDuration;
 import com.woowacourse.pelotonbackend.race.domain.Race;
 import com.woowacourse.pelotonbackend.race.domain.RaceCategory;
@@ -47,7 +45,8 @@ public class RaceDetailResponse {
 
     private final DateTimeDuration missionDuration;
 
-    public static RaceDetailResponse of(final Race race, final List<Mission> missions) {
+    public static RaceDetailResponse of(final Race race, final DateTimeDuration missionDuration,
+        final List<DayOfWeek> days) {
         return builder()
             .id(race.getId())
             .title(race.getTitle())
@@ -56,9 +55,9 @@ public class RaceDetailResponse {
             .certificationExample(race.getCertificationExample())
             .category(race.getCategory())
             .entranceFee(race.getEntranceFee())
-            .days(Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY))
+            .days(days)
             .raceDuration(race.getRaceDuration())
-            .missionDuration(missions.get(0).getMissionDuration())
+            .missionDuration(missionDuration)
             .build();
     }
 }

--- a/src/main/java/com/woowacourse/pelotonbackend/query/presentation/dto/RaceDetailResponse.java
+++ b/src/main/java/com/woowacourse/pelotonbackend/query/presentation/dto/RaceDetailResponse.java
@@ -2,10 +2,12 @@ package com.woowacourse.pelotonbackend.query.presentation.dto;
 
 import java.beans.ConstructorProperties;
 import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.woowacourse.pelotonbackend.certification.domain.TimeDuration;
 import com.woowacourse.pelotonbackend.mission.domain.DateTimeDuration;
 import com.woowacourse.pelotonbackend.race.domain.DateDuration;
 import com.woowacourse.pelotonbackend.race.domain.Race;
@@ -43,7 +45,7 @@ public class RaceDetailResponse {
 
     private final DateDuration raceDuration;
 
-    private final DateTimeDuration missionDuration;
+    private final TimeDuration missionDuration;
 
     public static RaceDetailResponse of(final Race race, final DateTimeDuration missionDuration,
         final List<DayOfWeek> days) {
@@ -57,7 +59,14 @@ public class RaceDetailResponse {
             .entranceFee(race.getEntranceFee())
             .days(days)
             .raceDuration(race.getRaceDuration())
-            .missionDuration(missionDuration)
+            .missionDuration(toTimeDuration(missionDuration))
             .build();
+    }
+
+    private static TimeDuration toTimeDuration(final DateTimeDuration missionDuration) {
+        final LocalTime startTime = missionDuration.getStartTime().toLocalTime();
+        final LocalTime endTime = missionDuration.getEndTime().toLocalTime();
+
+        return new TimeDuration(startTime, endTime);
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/docs/QueryDocumentation.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/docs/QueryDocumentation.java
@@ -135,10 +135,10 @@ public class QueryDocumentation {
                 fieldWithPath("days").type(ARRAY).description("Mission 수행 요일"),
                 fieldWithPath("mission_duration").type(OBJECT).description("Mission 시간"),
                 fieldWithPath("mission_duration.start_time").type(STRING)
-                    .attributes(getDateFormat())
+                    .attributes(getTimeFormat())
                     .description("Mission 시작 시각"),
                 fieldWithPath("mission_duration.end_time").type(STRING)
-                    .attributes(getDateFormat())
+                    .attributes(getTimeFormat())
                     .description("Mission 종료 시각"),
                 fieldWithPath("category").type(STRING).attributes(getRaceCategoryFormat()).description("Race 종류"),
                 fieldWithPath("entrance_fee").type(STRING).description("레이스 입장료")

--- a/src/test/java/com/woowacourse/pelotonbackend/docs/QueryDocumentation.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/docs/QueryDocumentation.java
@@ -107,4 +107,42 @@ public class QueryDocumentation {
             )
         );
     }
+
+    public static RestDocumentationResultHandler getRaceDetail() {
+        return document("queries/get-race-detail",
+            getDocumentRequest(),
+            getDocumentResponse(),
+            requestHeaders(
+                headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰"),
+                headerWithName(HttpHeaders.ACCEPT).description("Accept 헤더")
+            ),
+            pathParameters(
+                parameterWithName("raceId").description("Race ID")
+            ),
+            responseFields(
+                fieldWithPath("id").type(NUMBER).description("Race Id"),
+                fieldWithPath("title").type(STRING).description("레이스 제목"),
+                fieldWithPath("description").type(STRING).description("레이스 상세내용"),
+                fieldWithPath("thumbnail").type(STRING).description("썸네일 이미지"),
+                fieldWithPath("certification_example").type(STRING).description("인증 예시 이미지"),
+                fieldWithPath("race_duration").type(OBJECT).description("Race 기간"),
+                fieldWithPath("race_duration.start_date").type(STRING)
+                    .attributes(getDateFormat())
+                    .description("Race 시작 날짜"),
+                fieldWithPath("race_duration.end_date").type(STRING)
+                    .attributes(getDateFormat())
+                    .description("Race 종료 날짜"),
+                fieldWithPath("days").type(ARRAY).description("Mission 수행 요일"),
+                fieldWithPath("mission_duration").type(OBJECT).description("Mission 시간"),
+                fieldWithPath("mission_duration.start_time").type(STRING)
+                    .attributes(getDateFormat())
+                    .description("Mission 시작 시각"),
+                fieldWithPath("mission_duration.end_time").type(STRING)
+                    .attributes(getDateFormat())
+                    .description("Mission 종료 시각"),
+                fieldWithPath("category").type(STRING).attributes(getRaceCategoryFormat()).description("Race 종류"),
+                fieldWithPath("entrance_fee").type(STRING).description("레이스 입장료")
+            )
+        );
+    }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/mission/domain/MissionFixture.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/mission/domain/MissionFixture.java
@@ -223,4 +223,10 @@ public class MissionFixture {
             RaceFixture.createWithId(RaceFixture.TEST_RACE_ID),
             CertificationFixture.createCertificationWithId());
     }
+
+    public static List<Mission> createMissionsWithRaceId(final Long raceId) {
+        return createMissionsWithId(Arrays.asList(4L, 5L, 6L)).stream()
+            .map(mission -> mission.toBuilder().raceId(AggregateReference.to(raceId)).build())
+            .collect(Collectors.toList());
+    }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/query/application/QueryServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/query/application/QueryServiceTest.java
@@ -33,6 +33,7 @@ import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import com.woowacourse.pelotonbackend.certification.domain.Certification;
 import com.woowacourse.pelotonbackend.certification.domain.CertificationFixture;
 import com.woowacourse.pelotonbackend.certification.domain.CertificationRepository;
+import com.woowacourse.pelotonbackend.certification.domain.TimeDuration;
 import com.woowacourse.pelotonbackend.certification.presentation.dto.CertificationResponse;
 import com.woowacourse.pelotonbackend.member.domain.MemberFixture;
 import com.woowacourse.pelotonbackend.mission.domain.Mission;
@@ -205,7 +206,7 @@ class QueryServiceTest {
 
         assertAll(
             () -> assertThat(raceDetail).isEqualToComparingOnlyGivenFields(race, "id", "title", "description", "thumbnail", "certificationExample", "category", "entranceFee", "raceDuration"),
-            () -> assertThat(raceDetail).isEqualToComparingOnlyGivenFields(missions.get(0),"missionDuration"),
+            () -> assertThat(raceDetail.getMissionDuration()).isEqualTo(new TimeDuration(START_TIME.toLocalTime(), END_TIME.toLocalTime())),
             () -> assertThat(raceDetail.getDays()).isEqualTo(Arrays.asList(MISSION_DURATION.getStartTime().getDayOfWeek()))
         );
     }

--- a/src/test/java/com/woowacourse/pelotonbackend/query/application/QueryServiceTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/query/application/QueryServiceTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,7 @@ import com.woowacourse.pelotonbackend.member.domain.MemberFixture;
 import com.woowacourse.pelotonbackend.mission.domain.Mission;
 import com.woowacourse.pelotonbackend.mission.domain.MissionFixture;
 import com.woowacourse.pelotonbackend.mission.domain.MissionRepository;
+import com.woowacourse.pelotonbackend.query.presentation.dto.RaceDetailResponse;
 import com.woowacourse.pelotonbackend.query.presentation.dto.UpcomingMissionResponses;
 import com.woowacourse.pelotonbackend.race.domain.Race;
 import com.woowacourse.pelotonbackend.race.domain.RaceFixture;
@@ -189,5 +191,22 @@ class QueryServiceTest {
         final UpcomingMissionResponses responses = queryService.retrieveUpcomingMissionsBy(memberResponse());
 
         assertThat(responses.getUpcomingMissions()).hasSize(0);
+    }
+
+    @DisplayName("레이스 id로 레이스 상세정보를 조회한다")
+    @Test
+    void findRaceDetail() {
+        final Race race = RaceFixture.createWithId(TEST_RACE_ID);
+        final List<Mission> missions = MissionFixture.createMissionsWithRaceId(TEST_RACE_ID);
+        when(raceRepository.findById(TEST_RACE_ID)).thenReturn(Optional.of(race));
+        when(missionRepository.findByRaceId(TEST_RACE_ID)).thenReturn(missions);
+
+        final RaceDetailResponse raceDetail = queryService.findRaceDetail(TEST_RACE_ID);
+
+        assertAll(
+            () -> assertThat(raceDetail).isEqualToComparingOnlyGivenFields(race, "id", "title", "description", "thumbnail", "certificationExample", "category", "entranceFee", "raceDuration"),
+            () -> assertThat(raceDetail).isEqualToComparingOnlyGivenFields(missions.get(0),"missionDuration"),
+            () -> assertThat(raceDetail.getDays()).isEqualTo(Arrays.asList(MISSION_DURATION.getStartTime().getDayOfWeek()))
+        );
     }
 }

--- a/src/test/java/com/woowacourse/pelotonbackend/query/presentation/QueryControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/query/presentation/QueryControllerTest.java
@@ -46,6 +46,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.pelotonbackend.certification.domain.Certification;
 import com.woowacourse.pelotonbackend.certification.domain.CertificationFixture;
+import com.woowacourse.pelotonbackend.certification.domain.TimeDuration;
 import com.woowacourse.pelotonbackend.common.ErrorCode;
 import com.woowacourse.pelotonbackend.common.exception.RaceNotFoundException;
 import com.woowacourse.pelotonbackend.common.exception.TokenInvalidException;
@@ -150,7 +151,7 @@ class QueryControllerTest {
         when(bearerAuthInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class),
             any(HandlerMethod.class))).thenReturn(true);
 
-        mockMvc.perform(get("/api/queries/races/{raceId}/certifications", RaceFixture.TEST_RACE_ID)
+        mockMvc.perform(get("/api/queries/races/{raceId}/certifications", TEST_RACE_ID)
             .header(HttpHeaders.AUTHORIZATION, LoginFixture.getTokenHeader())
             .accept(MediaType.APPLICATION_JSON)
         )
@@ -162,11 +163,11 @@ class QueryControllerTest {
     @Test
     void findCertificationByNotExistRaceId() throws Exception {
         when(queryService.findCertificationsByRaceId(anyLong(), any(Pageable.class)))
-            .thenThrow(new RaceNotFoundException(RaceFixture.TEST_RACE_ID));
+            .thenThrow(new RaceNotFoundException(TEST_RACE_ID));
         when(bearerAuthInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class),
             any(HandlerMethod.class))).thenReturn(true);
 
-        mockMvc.perform(get("/api/queries/races/{raceId}/certifications", RaceFixture.TEST_RACE_ID)
+        mockMvc.perform(get("/api/queries/races/{raceId}/certifications", TEST_RACE_ID)
             .header(HttpHeaders.AUTHORIZATION, LoginFixture.getTokenHeader())
             .accept(MediaType.APPLICATION_JSON)
         )
@@ -225,9 +226,11 @@ class QueryControllerTest {
         final byte[] content = mvcResult.getResponse().getContentAsByteArray();
         final RaceDetailResponse actualResponse = objectMapper.readValue(content, RaceDetailResponse.class);
 
+        final TimeDuration expectedTimeDuration = new TimeDuration(MissionFixture.START_TIME.toLocalTime(),
+            MissionFixture.END_TIME.toLocalTime());
         assertAll(
             () -> assertThat(actualResponse).isEqualToComparingOnlyGivenFields(race, "id", "title", "description", "thumbnail", "certificationExample", "category", "entranceFee", "raceDuration"),
-            () -> assertThat(actualResponse.getMissionDuration()).isEqualTo(MissionFixture.MISSION_DURATION),
+            () -> assertThat(actualResponse.getMissionDuration()).isEqualTo(expectedTimeDuration),
             () -> assertThat(actualResponse.getDays()).isEqualTo(days)
         );
     }

--- a/src/test/java/com/woowacourse/pelotonbackend/query/presentation/QueryControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/query/presentation/QueryControllerTest.java
@@ -219,6 +219,7 @@ class QueryControllerTest {
             .accept(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk())
+            .andDo(QueryDocumentation.getRaceDetail())
             .andReturn();
 
         final byte[] content = mvcResult.getResponse().getContentAsByteArray();

--- a/src/test/java/com/woowacourse/pelotonbackend/query/presentation/QueryControllerTest.java
+++ b/src/test/java/com/woowacourse/pelotonbackend/query/presentation/QueryControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.DayOfWeek;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,7 +54,6 @@ import com.woowacourse.pelotonbackend.member.domain.LoginFixture;
 import com.woowacourse.pelotonbackend.member.domain.MemberFixture;
 import com.woowacourse.pelotonbackend.member.presentation.LoginMemberArgumentResolver;
 import com.woowacourse.pelotonbackend.member.presentation.dto.MemberResponse;
-import com.woowacourse.pelotonbackend.mission.domain.Mission;
 import com.woowacourse.pelotonbackend.mission.domain.MissionFixture;
 import com.woowacourse.pelotonbackend.query.application.QueryService;
 import com.woowacourse.pelotonbackend.query.presentation.dto.RaceCertificationsResponse;
@@ -207,8 +207,8 @@ class QueryControllerTest {
     @Test
     void findRaceDetail() throws Exception {
         final Race race = createWithId(TEST_RACE_ID);
-        final List<Mission> missions = MissionFixture.createMissionsWithRaceId(TEST_RACE_ID);
-        final RaceDetailResponse response = RaceDetailResponse.of(race, missions);
+        final List<DayOfWeek> days =  Arrays.asList(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY);
+        final RaceDetailResponse response = RaceDetailResponse.of(race, MissionFixture.MISSION_DURATION, days);
 
         when(queryService.findRaceDetail(anyLong())).thenReturn(response);
         when(bearerAuthInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class),
@@ -226,7 +226,8 @@ class QueryControllerTest {
 
         assertAll(
             () -> assertThat(actualResponse).isEqualToComparingOnlyGivenFields(race, "id", "title", "description", "thumbnail", "certificationExample", "category", "entranceFee", "raceDuration"),
-            () -> assertThat(actualResponse).isEqualToComparingOnlyGivenFields(missions.get(0),"missionDuration")
+            () -> assertThat(actualResponse.getMissionDuration()).isEqualTo(MissionFixture.MISSION_DURATION),
+            () -> assertThat(actualResponse.getDays()).isEqualTo(days)
         );
     }
 }


### PR DESCRIPTION
레이스 상세정보 화면에서 필요한 정보를 한꺼번에 불러오는 API를 구현했습니다.
프론트 작업은 별도의 브랜치에서 진행할 예정입니다.